### PR TITLE
Added default debug options

### DIFF
--- a/T3D/T3D/DefaultDebugOptions.h
+++ b/T3D/T3D/DefaultDebugOptions.h
@@ -1,0 +1,22 @@
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// DefaultDebugOptions.h
+//
+// Set default debug options. Applied when starting a WinGLApplication
+#pragma once
+
+namespace T3D
+{
+	class DefaultDebugOptions
+	{
+	public:
+		static const bool showWireframe = false;
+		static const bool showAxes		= false;
+		static const bool showGrid		= false;
+		static const bool showVertices	= false;
+	};
+}

--- a/T3D/T3D/T3D.vcxproj
+++ b/T3D/T3D/T3D.vcxproj
@@ -101,6 +101,7 @@
     <ClInclude Include="Quaternion.h" />
     <ClInclude Include="Renderer.h" />
     <ClInclude Include="RotateBehaviour.h" />
+    <ClInclude Include="DefaultDebugOptions.h" />
     <ClInclude Include="Shader.h" />
     <ClInclude Include="ShaderTest.h" />
     <ClInclude Include="Sound.h" />

--- a/T3D/T3D/T3D.vcxproj.filters
+++ b/T3D/T3D/T3D.vcxproj.filters
@@ -386,5 +386,8 @@
     <ClInclude Include="ParticleGravity.h">
       <Filter>Header Files\Component</Filter>
     </ClInclude>
+    <ClInclude Include="DefaultDebugOptions.h">
+      <Filter>Header Files\Application</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/T3D/T3D/WinGLApplication.cpp
+++ b/T3D/T3D/WinGLApplication.cpp
@@ -15,6 +15,8 @@
 #include <sdl\SDL_ttf.h>
 
 #include "WinGLApplication.h"
+
+#include "DefaultDebugOptions.h"
 #include "GLRenderer.h"
 #include "Transform.h"
 #include "GameObject.h"
@@ -61,6 +63,16 @@ namespace T3D
 		if(SDL_Init(SDL_INIT_EVERYTHING) < 0) {
 			return false;
 		}
+
+		//Load from DefaultDebugOptions
+		if (DefaultDebugOptions::showWireframe)
+			renderer->toggleWireframe();
+		if (DefaultDebugOptions::showAxes)
+			renderer->toggleAxes();
+		if (DefaultDebugOptions::showGrid)
+			renderer->toggleGrid();
+		if (DefaultDebugOptions::showVertices)
+			renderer->togglePoints();
 		
 		//Initialize SDL_mixer
 		soundManager->init();


### PR DESCRIPTION
Added a way to set default debug options e.g. showWireframe and showAxes. These defaults will be applied when starting a WinGLApplication preventing the need to press multiple keys every time a user wants to test/debug code.