### PR TITLE
DrawTask debug helpers

### DIFF
--- a/T3D/T3D/Animation.cpp
+++ b/T3D/T3D/Animation.cpp
@@ -14,17 +14,11 @@
 
 namespace T3D
 {
-	Animation::Animation(float duration) : duration(duration)
-	{
-		time = 0;
-		looping = false;
-		playing = false;
-	}
+	Animation::Animation(float duration) : duration(duration),
+										   time(0),
+										   looping(false),
+										   playing(false) { }
 
-
-	Animation::~Animation(void)
-	{
-	}
 
 	void Animation::addKey(std::string n, float time, Quaternion rot, Vector3 pos){
 		BoneMap::iterator it = bones.find(n);

--- a/T3D/T3D/Animation.cpp
+++ b/T3D/T3D/Animation.cpp
@@ -14,12 +14,17 @@
 
 namespace T3D
 {
+	// Create an animation of length `duration`. 
+	// Does _not_ play or loop by default.
 	Animation::Animation(float duration) : duration(duration),
 										   time(0),
 										   looping(false),
 										   playing(false) { }
 
 
+	// Adds a named keyframe describing a rotation and position beginning at a provided timestep.
+	// NOTE(Evan): This is incorrect if the provided time is outside the animation's range.
+	//             Should this be clamped to the animation's range and logged?
 	void Animation::addKey(std::string n, float time, Quaternion rot, Vector3 pos){
 		BoneMap::iterator it = bones.find(n);
 
@@ -32,6 +37,7 @@ namespace T3D
 		bones[n]->addFrame(f);
 	}
 
+	// Adds a bone to the parent game object.
 	void Animation::addBone(std::string n)
 	{
 		Bone *b = new Bone();
@@ -43,6 +49,8 @@ namespace T3D
 		}
 	}
 
+	// Integrate the change in time `dt` to the animation's state.
+	// Looping animations are reset to the beginning, and non-looping animations are flagged as finished.
 	void Animation::update(float dt){		
 		if (playing){
 			time += dt;

--- a/T3D/T3D/Animation.h
+++ b/T3D/T3D/Animation.h
@@ -30,20 +30,25 @@ namespace T3D
 		public Component
 	{
 	public:
+		// Create an animation of length `duration`. 
+		// Does not play or loop by default.
 		Animation(float duration);
 		virtual ~Animation() = default;
-		
 		virtual void update(float dt);
 
+		// Adds a bone to the parent game object.
 		void addBone(std::string n);
+
+		// Adds a named keyframe describing a rotation and position beginning at a provided timestep.
 		void addKey(std::string n, float time, Quaternion rot, Vector3 pos);
 
-		void play(){ time = 0; playing = true; }
-		void pause(){ playing = false; }
-		void loop(bool loop){ looping = loop; } 
+		// Runtime helper functions.
+		void play()          { time = 0; playing = true; }
+		void pause()         { playing = false;          }
+		void loop(bool loop) { looping = loop;           } 
 
-		void printFrames()
-        {
+		// Log all keyframes for the animation.
+		void printFrames() {
             std::cout << "Animation:\n";
 			BoneMap::iterator it;
 			for (it = bones.begin(); it!= bones.end(); it++){
@@ -53,25 +58,12 @@ namespace T3D
 			}
         }
 
-		void printKeyFrames()
-        {
-            std::cout << "Animation:\n";
-			BoneMap::iterator it;
-			for (it = bones.begin(); it!= bones.end(); it++){
-				std::cout << "bone: " << it->first << "\n";
-				Bone *b = it->second;
-				b->printKeyFrames();
-			}
-        }
-
 	protected:
 		BoneMap bones;
-		float duration;
-		int frames;
-
-		float time;
-		bool playing;
-		bool looping;
+		float   duration;
+		float   time;
+		bool    playing;
+		bool    looping;
 	};
 }
 

--- a/T3D/T3D/Animation.h
+++ b/T3D/T3D/Animation.h
@@ -54,7 +54,7 @@ namespace T3D
 			for (it = bones.begin(); it!= bones.end(); it++){
 				std::cout << "bone: " << it->first << "\n";
 				Bone *b = it->second;
-				b->printFrames();
+				b->printKeyFrames();
 			}
         }
 

--- a/T3D/T3D/Animation.h
+++ b/T3D/T3D/Animation.h
@@ -31,7 +31,7 @@ namespace T3D
 	{
 	public:
 		Animation(float duration);
-		virtual ~Animation();
+		virtual ~Animation() = default;
 		
 		virtual void update(float dt);
 

--- a/T3D/T3D/Billboard.cpp
+++ b/T3D/T3D/Billboard.cpp
@@ -17,10 +17,7 @@
 
 namespace T3D
 {
-	Billboard::~Billboard(void)
-	{
-	}
-	
+	// Initialise the Billboard component with its parent GameObject.
 	void Billboard::init(GameObject* go){
 		gameObject = go;
 		
@@ -28,6 +25,7 @@ namespace T3D
 		gameObject->setMesh(mesh);
 	}
 	
+	// Update the Billboard's facing every frame to ensure it's looking at the camera.
 	void Billboard::update(float dt){	
 		Vector3 target = camera->getWorldPosition();
 

--- a/T3D/T3D/Billboard.h
+++ b/T3D/T3D/Billboard.h
@@ -21,13 +21,18 @@ namespace T3D
 		public Component
 	{
 	public:
-		Billboard(Transform* camera, bool lockY = false) : lockY(lockY),camera(camera){};
-		~Billboard(void);
+		// Creates a Billboard associated with a Camera. May rotate about the Y axis by default.
+		// A Billboard should be initialised with a parent GameObject using its init method before it can be used.
+		Billboard(Transform* camera, bool lockY = false) : lockY(lockY),
+		                                                   camera(camera) { };
+		~Billboard(void) = default;
 
+		// Update the Billboard's facing every frame to ensure it's looking at the camera.
 		virtual void update(float dt);
 		virtual void init(GameObject* go);
 
-		void lockYAxis(){ lockY = true; }
+		// Helper functions.
+		void lockYAxis()  { lockY = true; }
 		void unlockYAxis(){ lockY = false; }
 
 	private:

--- a/T3D/T3D/Bone.cpp
+++ b/T3D/T3D/Bone.cpp
@@ -12,20 +12,8 @@
 
 namespace T3D
 {	
-	bool frameCompare (KeyFrame f1, KeyFrame f2) { 
-		return (f1.time<f2.time); 
-	}
-
-	Bone::Bone(void)
-	{
-	}
-
-
-	Bone::~Bone(void)
-	{
-	}
-
-	
+	// Add a KeyFrame to the Animation Bone. 
+	// Works for arbitrary times -- Bones do not need to be declared and inserted in order.
 	void Bone::addFrame(KeyFrame f){
 		if (keyframes.empty()){
 			keyframes.push_back(f);
@@ -39,7 +27,7 @@ namespace T3D
 	}
 	
 
-
+	// Update the Bone's position by interpolating between the current and next keyframes.
 	void Bone::update(float time){
 		int frame = 0;
 		if (!keyframes.empty())
@@ -63,6 +51,7 @@ namespace T3D
 		}
 	}
 
+	// Dump information for this bone to standard output.
 	void Bone::printKeyFrames(){
 		std::vector<KeyFrame>::iterator kfi;
 		for (kfi=keyframes.begin(); kfi!=keyframes.end(); kfi++){

--- a/T3D/T3D/Bone.h
+++ b/T3D/T3D/Bone.h
@@ -12,7 +12,6 @@
 #define BONE_H
 
 #include <vector>
-#include <list>
 #include "Transform.h"
 
 namespace T3D
@@ -27,18 +26,17 @@ namespace T3D
 	class Bone
 	{
 	public:
-		Bone(void);
-		~Bone(void);
+		Bone(void) = default;
+		~Bone(void) = default;
 
-		void interpolate(int numFrames);
 		void update(float time);
-
 		void addFrame(KeyFrame f);
 
-		void printFrames();
+		// Dump information for this bone to standard output.
 		void printKeyFrames();
 
-		Transform* transform;
+		// Accessed by Animation.
+		Transform* transform = NULL;
 		std::vector<KeyFrame> keyframes;
 	};
 }

--- a/T3D/T3D/Camera.cpp
+++ b/T3D/T3D/Camera.cpp
@@ -14,20 +14,6 @@
 
 namespace T3D
 {
-
-	// Safe default perspective camera
-	Camera::Camera()
-	{
-		gameObject = 0;
-
-		// Default perspective camera
-		this->type = Camera::PERSPECTIVE;
-		this->near = 0.1;
-		this->far = 500.0;
-		this->fovy = 45.0;
-		this->aspect = 1.6;
-	}
-
 	// constructor with perspective parameters
 	Camera::Camera(projectionType type, double near, double far, double fovy, double aspect)
 	{
@@ -61,10 +47,6 @@ namespace T3D
 		this->right = right;
 		this->bottom = bottom;
 		this->top = top;
-	}
-
-	Camera::~Camera(void)
-	{
 	}
 
 }

--- a/T3D/T3D/Camera.h
+++ b/T3D/T3D/Camera.h
@@ -11,7 +11,6 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
-#include <vector>
 #include "Component.h"
 #include "Plane.h"
 #include "Transform.h"
@@ -28,12 +27,17 @@ namespace T3D
 		} projectionType;
 
 		// Safe default perspective camera
-		Camera();
+		Camera::Camera() : type      (Camera::PERSPECTIVE),
+						   near      (0.1),
+						   far       (500.0),
+						   fovy      (45.0),
+						   aspect    (1.6) { }
+
 		// constructor optimised with perspective parameters
 		Camera(projectionType type, double near, double far, double fovy, double aspect);
 		// constructor with orthographic parameters
 		Camera(projectionType type, double near, double far, double left, double right, double bottom, double top);
-		virtual ~Camera();
+		virtual ~Camera() = default;
 
 	public:
 		projectionType type;	// projection type
@@ -41,7 +45,7 @@ namespace T3D
 		double far;				// far z plane (distance from viewer)
 		double near;			// near Z plane (distance from viewer)
 
-		// Perspectve projection only
+		// Perspective projection only
 		double fovy;			// field of view (angle in degrees)
 		double aspect;			// field of view in X direction - ratio of x(width) to y(height)
 

--- a/T3D/T3D/Colour.cpp
+++ b/T3D/T3D/Colour.cpp
@@ -12,9 +12,5 @@
 
 namespace T3D
 {
-
-	Colour::~Colour(void)
-	{
-	}
-
+	/* Plain old data class : Implementation inside header */ 
 }

--- a/T3D/T3D/Colour.h
+++ b/T3D/T3D/Colour.h
@@ -18,6 +18,8 @@ namespace T3D
 	class Colour
 	{
 	public:
+		// Create a Colour from 'rgba' components.
+		// _Assumes 0 > (r|g|b|a) > 255_.
 		Colour(int r, int g, int b, int a) : r(r), b(b), g(g), a(a){}
 
 		Colour(uint32_t hex){
@@ -27,7 +29,7 @@ namespace T3D
 			a = hex & 0xff;
 		}
 
-		~Colour(void);
+		~Colour(void) = default;
 
 		int r,g,b,a;
 	};

--- a/T3D/T3D/Component.cpp
+++ b/T3D/T3D/Component.cpp
@@ -15,13 +15,4 @@
 
 namespace T3D
 {
-	Component::Component(void)
-	{
-		gameObject = NULL;
-	}
-
-
-	Component::~Component(void)
-	{
-	}
 }

--- a/T3D/T3D/Component.cpp
+++ b/T3D/T3D/Component.cpp
@@ -15,4 +15,5 @@
 
 namespace T3D
 {
+	/* Abstract class : Implementation not provided */ 
 }

--- a/T3D/T3D/Component.h
+++ b/T3D/T3D/Component.h
@@ -20,11 +20,11 @@ namespace T3D
 	class Component
 	{
 	public:
-		Component(void);
-		virtual ~Component(void);
+		Component(void) : gameObject(nullptr) { }
+		virtual ~Component(void) = default;
 
-		virtual void update(float dt){};
-		virtual void init(GameObject* go){ gameObject = go; };
+		virtual void update(float dt)     { /* overridden */ };
+		virtual void init(GameObject* go) { gameObject = go; };
 
 	public:
 		GameObject *gameObject;

--- a/T3D/T3D/Cube.cpp
+++ b/T3D/T3D/Cube.cpp
@@ -58,17 +58,17 @@ namespace T3D
 		// Build quads
 		pos = 0;
 		//front
-		setFace(pos++,3,2,1,0);
+		setQuadFace(pos++,3,2,1,0);
 		//back
-		setFace(pos++,4,5,6,7);
+		setQuadFace(pos++,4,5,6,7);
 		//left
-		setFace(pos++,11,10,9,8);
+		setQuadFace(pos++,11,10,9,8);
 		//right
-		setFace(pos++,12,13,14,15);
+		setQuadFace(pos++,12,13,14,15);
 		//bottom
-		setFace(pos++,19,18,17,16);
+		setQuadFace(pos++,19,18,17,16);
 		//top
-		setFace(pos++,20,21,22,23);
+		setQuadFace(pos++,20,21,22,23);
 
 		// Check vertex and index arrays
 		checkArrays();

--- a/T3D/T3D/DiagMessageTask.cpp
+++ b/T3D/T3D/DiagMessageTask.cpp
@@ -74,7 +74,7 @@ namespace T3D{
 		{
 			time -= dt;
 			if (time < 0.0f)
-				setFinsihed(true);
+				setFinished(true);
 		}
 
 		if (refresh)

--- a/T3D/T3D/DrawTask.cpp
+++ b/T3D/T3D/DrawTask.cpp
@@ -16,7 +16,54 @@ namespace T3D {
 	DrawTask::DrawTask(T3DApplication *app, Texture* tex) : Task(app)
 	{
 		drawArea = tex;
+
+		// Reserve some space for the buffer, as it's extremely unlikely just one pixel will be plotted, and
+		// the common case is filled, non-sparse shapes
+		const uint32_t pixelsToReserve = 512;
+		pixelPlotQueue.reserve(pixelsToReserve);
+
 		init();
+	}
+
+	// Add a pixel to be displayed this frame to the PixelPlotQueue.
+	void DrawTask::pushPixel(int x, int y, Colour colour)
+	{
+		pixelPlotQueue.push_back(Pixel { x, y, colour }); 
+	}
+
+	// Plots every pixel pushed to the DrawTask's pixel queue this frame before clearing the queue.
+	// If a pixel's X or Y coordinate is outside the drawable surface bounds, an error message is reported to stdout.
+	// Otherwise, the pixel is written to the surface.
+	void DrawTask::flushPixelQueue()
+	{
+		for (auto &Pixel : pixelPlotQueue)
+		{
+			bool PixelWithinWidth  = (Pixel.x >= 0 && Pixel.x < drawArea->getWidth());
+			bool PixelWithinHeight = (Pixel.y >= 0 && Pixel.y < drawArea->getHeight());
+			bool PixelWithinBounds = (PixelWithinWidth && PixelWithinHeight);
+
+			if (PixelWithinBounds)
+			{
+				drawArea->plotPixel(Pixel.x, Pixel.y, Pixel.colour);
+			}
+			else
+			{
+				printf("Pixel out of bounds!\n"
+					   "\tWidth  :: [0 <= X <= %4u :: %4d :: %5s]\n"
+					   "%s"
+					   "\tHeight :: [0 <= Y <= %4u :: %4d :: %5s]\n"
+					   "%s"
+					   ,
+					   T3D::WindowWidth,
+					   Pixel.x, PixelWithinWidth  ? "OK" : "ERROR",
+					   PixelWithinWidth  ?   ""  : "                                      ^^^\n",
+					   T3D::WindowHeight,
+					   Pixel.y, PixelWithinHeight ? "OK" : "ERROR",
+					   PixelWithinHeight  ?  ""  : "                                      ^^^\n");
+			}
+		}
+
+		pixelPlotQueue.clear();
 	}
 
 
@@ -33,7 +80,7 @@ namespace T3D {
 		float ystep = float(y2-y1)/(x2-x1);
 		float y = y1;
 		for (int x = x1; x<x2; x++){
-			drawArea->plotPixel(x,int(y),c);
+			pushPixel(x, int(y), c);
 			y += ystep;
 		}
 	}
@@ -42,9 +89,13 @@ namespace T3D {
 	}
 
 	void DrawTask::update(float dt){
-		//drawArea->clear(Colour(255,255,255,255));
+		drawArea->clear(Colour(255, 255, 255, 255));
+		drawDDALine(100, 100, 200, 200, Colour(255,0,0,255));
 
+		// Plots pixels made to the drawing area this frame and clears the pixel queue.
+		flushPixelQueue();
 		app->getRenderer()->reloadTexture(drawArea);
 	}
+
 
 }

--- a/T3D/T3D/DrawTask.cpp
+++ b/T3D/T3D/DrawTask.cpp
@@ -13,6 +13,15 @@
 
 namespace T3D {
 
+	// Creates a DrawTask that draws onto the Texture tex once per frame.
+	//
+	// Usage notes:
+	// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
+	//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
+	//
+	// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
+	//
+	// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
 	DrawTask::DrawTask(T3DApplication *app, Texture* tex) : Task(app)
 	{
 		drawArea = tex;
@@ -67,15 +76,16 @@ namespace T3D {
 	}
 
 
-	DrawTask::~DrawTask(void)
-	{
-	}
-
-	void DrawTask::init(){		
+	// Ensures all pre-conditions are met for following calls to the `update` function.
+	// NOTE(Evan): This should really be inlined into the constructor or at least made private.
+	void DrawTask::init	(){		
 		drawArea->clear(Colour(255,255,255,255));
 		drawDDALine(100,100,200,200,Colour(0,0,0,255));
 	}
 
+
+	// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
+	// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
 	void DrawTask::drawDDALine(int x1, int y1, int x2, int y2,Colour c){
 		float ystep = float(y2-y1)/(x2-x1);
 		float y = y1;
@@ -85,12 +95,19 @@ namespace T3D {
 		}
 	}
 		
+
+	// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
+	// Bresenham algorithm from the 2D drawing lectures.
+	// FIXME:
+	// - Not implemented yet! That's your job.
 	void DrawTask::drawBresLine(int x1, int y1, int x2, int y2,Colour c){
 	}
 
+
+	// Provides one frames' worth of pixels to draw onto the screen.
 	void DrawTask::update(float dt){
 		drawArea->clear(Colour(255, 255, 255, 255));
-		drawDDALine(100, 100, 200, 200, Colour(255,0,0,255));
+		drawDDALine(100, 10000, 200, 200, Colour(255,0,0,255));
 
 		// Plots pixels made to the drawing area this frame and clears the pixel queue.
 		flushPixelQueue();

--- a/T3D/T3D/DrawTask.h
+++ b/T3D/T3D/DrawTask.h
@@ -19,13 +19,34 @@ namespace T3D{
 		public Task
 	{
 	public:
+		// Creates a DrawTask that draws onto the Texture tex once per frame.
+		//
+		// Usage notes:
+		// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
+		//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
+		//
+		// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
+		//
+		// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
 		DrawTask(T3DApplication *app, Texture* tex);
-		~DrawTask(void);
+		~DrawTask(void) = default;
 
+
+		// Ensures all pre-conditions are met for following calls to the `update` function.
+		// NOTE(Evan): This should really be inlined into the constructor or at least made private.
 		void init();
+
+		// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
+		// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
 		void drawDDALine(int x1, int y1, int x2, int y2, Colour c);
+
+		// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
+		// Bresenham algorithm from the 2D drawing lectures.
+		// FIXME:
+		// - Not implemented yet! That's your job.
 		void drawBresLine(int x1, int y1, int x2, int y2, Colour c);
 
+		// Provides one frames' worth of pixels to draw onto the screen.
 		virtual void update(float dt);
 
 	private:

--- a/T3D/T3D/DrawTask.h
+++ b/T3D/T3D/DrawTask.h
@@ -30,6 +30,17 @@ namespace T3D{
 
 	private:
 		Texture *drawArea;
+
+		void pushPixel(int x, int y, Colour colour);
+		void flushPixelQueue();
+
+		struct Pixel
+		{
+			int x = 0;
+			int y = 0;
+			Colour colour = { 0xFF, 0, 0xFF, 0xFF }; // Anything dodgy should show up as purple.
+		};
+		std::vector<Pixel> pixelPlotQueue;
 	};
 
 }

--- a/T3D/T3D/Mesh.cpp
+++ b/T3D/T3D/Mesh.cpp
@@ -146,12 +146,12 @@ namespace T3D
 	Vector3 Mesh::getNormal(int i){
 		return Vector3(normals[i*3], normals[i*3+1], normals[i*3+2]);
 	}
-	void Mesh::setFace(int i, int a, int b, int c){
+	void Mesh::setTriFace(int i, int a, int b, int c){
 		triIndices[i*3] = a;
 		triIndices[i*3+1] = b;
 		triIndices[i*3+2] = c;
 	}
-	void Mesh::setFace(int i, int a, int b, int c, int d){
+	void Mesh::setQuadFace(int i, int a, int b, int c, int d){
 		quadIndices[i*4] = a;
 		quadIndices[i*4+1] = b;
 		quadIndices[i*4+2] = c;

--- a/T3D/T3D/Mesh.h
+++ b/T3D/T3D/Mesh.h
@@ -23,59 +23,53 @@ namespace T3D
 		Mesh(void);
 		virtual ~Mesh(void);
 
-		int getNumVerts(){
-			return numVerts;
-		}
+		// Accessors.
+		int           getNumVerts()    { return numVerts;    }
+		int           getNumTris()     { return numTris;     }
+		int           getNumQuads()    { return numQuads;    }
+		float*        getVertices()    { return vertices;    }
+		float*        getNormals()     { return normals;     }
+		float*        getColors()      { return colors;      }
+		float*        getUVs()         { return uvs;         }
+		unsigned int* getTriIndices()  { return triIndices;  }
+		unsigned int* getQuadIndices() { return quadIndices; }
 
-		int getNumTris(){
-			return numTris;
-		}
-		
-		int getNumQuads(){
-			return numQuads;
-		}
 
-		float* getVertices(){
-			return vertices;
-		}
-		float* getNormals(){
-			return normals;
-		}
-		float* getColors(){
-			return colors;
-		}
-		float* getUVs(){
-			return uvs;
-		}
-		unsigned int* getTriIndices(){
-			return triIndices;
-		}
-		unsigned int* getQuadIndices(){
-			return quadIndices;
-		}
 
+		// Initialises internal Vertex, Index and Colour buffers based on
+		// the number of vertices the caller requires to render primitives.
 		void initArrays(int numVerts, int numTris, int numQuads);
+
+		// Verbosely logs any vertices that are uninitialised.
+		// Call this at the end of _any_ procedural mesh generation!
 		bool checkArrays();
+
+		// Calculates normals for Triangles and Quads. 
+		// - Quad normals may look a bit off.
 		void calcNormals();
+		
+		// Negates all normals (i.e. flips them facing inwards to outwards, and vice versa)
 		void invertNormals();
+
+		// Procedural texture coordinate calculations for the primitives provided by T3D.
 		void calcUVSphere();
 		void calcUVPlaneXY();
 		void calcUVPlaneYZ();
 		void calcUVPlaneXZ();
 		void calcUVCube();
 
-		virtual void setVertex(int i, float x, float y, float z);
+		virtual void    setVertex(int i, float x, float y, float z);
 		virtual Vector3 getVertex(int i);
-		virtual void setColor(int i, float r, float g, float b, float a);
+		virtual void    setColor(int i, float r, float g, float b, float a);
 		virtual Vector4 getColor(int i);
-		virtual void setNormal(int i, float x, float y, float z);
-		virtual void setNormal(int i, Vector3 n);
-		virtual void addNormal(int i, Vector3 n);
-		virtual void normalise();
+		virtual void    setNormal(int i, float x, float y, float z);
+		virtual void    setNormal(int i, Vector3 n);
+		virtual void    addNormal(int i, Vector3 n);
+		virtual void    normalise();
 		virtual Vector3 getNormal(int i);
-		virtual void setFace(int i, int a, int b, int c);
-		virtual void setFace(int i, int a, int b, int c, int d);
-		virtual void setUV(int i, float u, float v);
+		virtual void    setTriFace(int i, int a, int b, int c);
+		virtual void    setQuadFace(int i, int a, int b, int c, int d);
+		virtual void    setUV(int i, float u, float v);
 
 	protected:
 		int numVerts, numTris, numQuads;

--- a/T3D/T3D/PlaneMesh.cpp
+++ b/T3D/T3D/PlaneMesh.cpp
@@ -19,8 +19,8 @@ namespace T3D{
 		int face = 0;
 		for (int i=0; i<density; i++){
 			for (int j=0; j<density; j++){
-				setFace(face++, i*(density+1)+j, i*(density+1)+j+1, (i+1)*(density+1)+j);
-				setFace(face++, (i+1)*(density+1)+j, i*(density+1)+j+1, (i+1)*(density+1)+j+1);
+				setTriFace(face++, i*(density+1)+j, i*(density+1)+j+1, (i+1)*(density+1)+j);
+				setTriFace(face++, (i+1)*(density+1)+j, i*(density+1)+j+1, (i+1)*(density+1)+j+1);
 			}
 		}
 

--- a/T3D/T3D/Renderer.h
+++ b/T3D/T3D/Renderer.h
@@ -19,6 +19,14 @@
 
 namespace T3D
 {
+	#define WINDOW_WIDTH		1024
+	#define	WINDOW_HEIGHT		640
+
+	// Width of the window provided by the OS layer, in pixels.
+	const uint32_t WindowWidth = WINDOW_WIDTH;
+	// Height of the window provided by the OS layer, in pixels.
+	const uint32_t WindowHeight = WINDOW_HEIGHT;
+
 	class Camera;
 
 	//! Generic class for renderers

--- a/T3D/T3D/Sphere.cpp
+++ b/T3D/T3D/Sphere.cpp
@@ -54,15 +54,15 @@ namespace T3D{
 
 		//top and bottom
 		for (int j=0; j<density; j++){
-			setFace(face++, density*(density-1)+1,(j+1)%density,j);
-			setFace(face++, density*(density-1), density*(density-2)+j, density*(density-2) + (j+1)%density);
+			setTriFace(face++, density*(density-1)+1,(j+1)%density,j);
+			setTriFace(face++, density*(density-1), density*(density-2)+j, density*(density-2) + (j+1)%density);
 		}
 
 		//rest
 		for (int i=1; i<density-1; i++){
 			for (int j=0; j<density; j++){
-				setFace(face++, (i-1)*density + j, (i-1)*density + (j+1)%density, i*density + j);
-				setFace(face++, (i-1)*density + (j+1)%density, i*density + (j+1)%density, i*density + j);
+				setTriFace(face++, (i-1)*density + j, (i-1)*density + (j+1)%density, i*density + j);
+				setTriFace(face++, (i-1)*density + (j+1)%density, i*density + (j+1)%density, i*density + j);
 			}
 		}
 

--- a/T3D/T3D/Sweep.cpp
+++ b/T3D/T3D/Sweep.cpp
@@ -30,7 +30,7 @@ namespace T3D
 				setVertex(vpos++,v.x,v.y,v.z);
 
 				if (closed || i<path.size()-1){
-					setFace(fpos++,(j+i*points.size()),
+					setQuadFace(fpos++,(j+i*points.size()),
 								   ((j+1)%points.size()+i*points.size()),
 								   ((j+1)%points.size()+((i+1)%path.size())*points.size()),
 								   (j+((i+1)%path.size())*points.size()));

--- a/T3D/T3D/Task.h
+++ b/T3D/T3D/Task.h
@@ -26,7 +26,7 @@ namespace T3D
 		virtual void update(float dt) = 0;
 
 		bool getFinished() { return finished; }
-		void setFinsihed(bool finished) { this->finished = finished; }
+		void setFinished(bool finished) { this->finished = finished; }
 		std::string& getName() { return name; }
 		void setName(const char *name) { this->name = name; }
 


### PR DESCRIPTION
## Add buffered and bounds-checked pixel plot function to `DrawTask`
The example `DrawTask.cpp` code no longer calls `plotPixel(x, c, rgba)` directly. It instead calls `pushPixel(x, y, rgba)` which pushes the to-be-drawn pixel onto a queue. This queue is processed in a batch with bounds-checking and helpful error messages before being cleared for that frame. The texture is then reloaded as normal.

The rationale is that its extremely unlikely that only one pixel will ever be drawn per frame but it's useful to have a function for emulating this need.
The basic error checking provided could be extended as there's a lot more context having the entire frames worth of pixels to plot. `SDL_MUSTLOCK()` & `SDL_UnlockSurface` can be called one time each for the entire queues content as well, rather then for  each pixel.


## Export WindowWidth & WindowHeight as Renderer global constants based on pre-processor symbols
As far as I can see, there's no viewport / scissor test / resizing code in the Renderer that makes these constants moot. 