### PR TITLE
DrawTask debug helpers

### DIFF
--- a/T3D/T3D/DrawTask.cpp
+++ b/T3D/T3D/DrawTask.cpp
@@ -16,7 +16,54 @@ namespace T3D {
 	DrawTask::DrawTask(T3DApplication *app, Texture* tex) : Task(app)
 	{
 		drawArea = tex;
+
+		// Reserve some space for the buffer, as it's extremely unlikely just one pixel will be plotted, and
+		// the common case is filled, non-sparse shapes
+		const uint32_t pixelsToReserve = 512;
+		pixelPlotQueue.reserve(pixelsToReserve);
+
 		init();
+	}
+
+	// Add a pixel to be displayed this frame to the PixelPlotQueue.
+	void DrawTask::pushPixel(int x, int y, Colour colour)
+	{
+		pixelPlotQueue.push_back(Pixel { x, y, colour }); 
+	}
+
+	// Plots every pixel pushed to the DrawTask's pixel queue this frame before clearing the queue.
+	// If a pixel's X or Y coordinate is outside the drawable surface bounds, an error message is reported to stdout.
+	// Otherwise, the pixel is written to the surface.
+	void DrawTask::flushPixelQueue()
+	{
+		for (auto &Pixel : pixelPlotQueue)
+		{
+			bool PixelWithinWidth  = (Pixel.x >= 0 && Pixel.x < drawArea->getWidth());
+			bool PixelWithinHeight = (Pixel.y >= 0 && Pixel.y < drawArea->getHeight());
+			bool PixelWithinBounds = (PixelWithinWidth && PixelWithinHeight);
+
+			if (PixelWithinBounds)
+			{
+				drawArea->plotPixel(Pixel.x, Pixel.y, Pixel.colour);
+			}
+			else
+			{
+				printf("Pixel out of bounds!\n"
+					   "\tWidth  :: [0 <= X <= %4u :: %4d :: %5s]\n"
+					   "%s"
+					   "\tHeight :: [0 <= Y <= %4u :: %4d :: %5s]\n"
+					   "%s"
+					   ,
+					   T3D::WindowWidth,
+					   Pixel.x, PixelWithinWidth  ? "OK" : "ERROR",
+					   PixelWithinWidth  ?   ""  : "                                      ^^^\n",
+					   T3D::WindowHeight,
+					   Pixel.y, PixelWithinHeight ? "OK" : "ERROR",
+					   PixelWithinHeight  ?  ""  : "                                      ^^^\n");
+			}
+		}
+
+		pixelPlotQueue.clear();
 	}
 
 
@@ -33,7 +80,7 @@ namespace T3D {
 		float ystep = float(y2-y1)/(x2-x1);
 		float y = y1;
 		for (int x = x1; x<x2; x++){
-			drawArea->plotPixel(x,int(y),c);
+			pushPixel(x, int(y), c);
 			y += ystep;
 		}
 	}
@@ -42,9 +89,13 @@ namespace T3D {
 	}
 
 	void DrawTask::update(float dt){
-		//drawArea->clear(Colour(255,255,255,255));
+		drawArea->clear(Colour(255, 255, 255, 255));
+		drawDDALine(100, 100, 200, 200, Colour(255,0,0,255));
 
+		// Plots pixels made to the drawing area this frame and clears the pixel queue.
+		flushPixelQueue();
 		app->getRenderer()->reloadTexture(drawArea);
 	}
+
 
 }

--- a/T3D/T3D/DrawTask.cpp
+++ b/T3D/T3D/DrawTask.cpp
@@ -13,6 +13,15 @@
 
 namespace T3D {
 
+	// Creates a DrawTask that draws onto the Texture tex once per frame.
+	//
+	// Usage notes:
+	// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
+	//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
+	//
+	// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
+	//
+	// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
 	DrawTask::DrawTask(T3DApplication *app, Texture* tex) : Task(app)
 	{
 		drawArea = tex;
@@ -67,15 +76,16 @@ namespace T3D {
 	}
 
 
-	DrawTask::~DrawTask(void)
-	{
-	}
-
-	void DrawTask::init(){		
+	// Ensures all pre-conditions are met for following calls to the `update` function.
+	// NOTE(Evan): This should really be inlined into the constructor or at least made private.
+	void DrawTask::init	(){		
 		drawArea->clear(Colour(255,255,255,255));
 		drawDDALine(100,100,200,200,Colour(0,0,0,255));
 	}
 
+
+	// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
+	// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
 	void DrawTask::drawDDALine(int x1, int y1, int x2, int y2,Colour c){
 		float ystep = float(y2-y1)/(x2-x1);
 		float y = y1;
@@ -85,12 +95,19 @@ namespace T3D {
 		}
 	}
 		
+
+	// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
+	// Bresenham algorithm from the 2D drawing lectures.
+	// FIXME:
+	// - Not implemented yet! That's your job.
 	void DrawTask::drawBresLine(int x1, int y1, int x2, int y2,Colour c){
 	}
 
+
+	// Provides one frames' worth of pixels to draw onto the screen.
 	void DrawTask::update(float dt){
 		drawArea->clear(Colour(255, 255, 255, 255));
-		drawDDALine(100, 100, 200, 200, Colour(255,0,0,255));
+		drawDDALine(100, 10000, 200, 200, Colour(255,0,0,255));
 
 		// Plots pixels made to the drawing area this frame and clears the pixel queue.
 		flushPixelQueue();

--- a/T3D/T3D/DrawTask.h
+++ b/T3D/T3D/DrawTask.h
@@ -19,13 +19,34 @@ namespace T3D{
 		public Task
 	{
 	public:
+		// Creates a DrawTask that draws onto the Texture tex once per frame.
+		//
+		// Usage notes:
+		// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
+		//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
+		//
+		// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
+		//
+		// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
 		DrawTask(T3DApplication *app, Texture* tex);
-		~DrawTask(void);
+		~DrawTask(void) = default;
 
+
+		// Ensures all pre-conditions are met for following calls to the `update` function.
+		// NOTE(Evan): This should really be inlined into the constructor or at least made private.
 		void init();
+
+		// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
+		// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
 		void drawDDALine(int x1, int y1, int x2, int y2, Colour c);
+
+		// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
+		// Bresenham algorithm from the 2D drawing lectures.
+		// FIXME:
+		// - Not implemented yet! That's your job.
 		void drawBresLine(int x1, int y1, int x2, int y2, Colour c);
 
+		// Provides one frames' worth of pixels to draw onto the screen.
 		virtual void update(float dt);
 
 	private:

--- a/T3D/T3D/DrawTask.h
+++ b/T3D/T3D/DrawTask.h
@@ -30,6 +30,17 @@ namespace T3D{
 
 	private:
 		Texture *drawArea;
+
+		void pushPixel(int x, int y, Colour colour);
+		void flushPixelQueue();
+
+		struct Pixel
+		{
+			int x = 0;
+			int y = 0;
+			Colour colour = { 0xFF, 0, 0xFF, 0xFF }; // Anything dodgy should show up as purple.
+		};
+		std::vector<Pixel> pixelPlotQueue;
 	};
 
 }

--- a/T3D/T3D/Renderer.h
+++ b/T3D/T3D/Renderer.h
@@ -19,6 +19,14 @@
 
 namespace T3D
 {
+	#define WINDOW_WIDTH		1024
+	#define	WINDOW_HEIGHT		640
+
+	// Width of the window provided by the OS layer, in pixels.
+	const uint32_t WindowWidth = WINDOW_WIDTH;
+	// Height of the window provided by the OS layer, in pixels.
+	const uint32_t WindowHeight = WINDOW_HEIGHT;
+
 	class Camera;
 
 	//! Generic class for renderers


### PR DESCRIPTION
## Add buffered and bounds-checked pixel plot function to `DrawTask`
The example `DrawTask.cpp` code no longer calls `plotPixel(x, c, rgba)` directly. It instead calls `pushPixel(x, y, rgba)` which pushes the to-be-drawn pixel onto a queue. This queue is processed in a batch with bounds-checking and helpful error messages before being cleared for that frame. The texture is then reloaded as normal.

The rationale is that its extremely unlikely that only one pixel will ever be drawn per frame but it's useful to have a function for emulating this need.
The basic error checking provided could be extended as there's a lot more context having the entire frames worth of pixels to plot. `SDL_MUSTLOCK()` & `SDL_UnlockSurface` can be called one time each for the entire queues content as well, rather then for  each pixel.


## Export WindowWidth & WindowHeight as Renderer global constants based on pre-processor symbols
As far as I can see, there's no viewport / scissor test / resizing code in the Renderer that makes these constants moot. 