### PR TITLE
Mesh and Billboard cleanup

### DIFF
--- a/T3D/T3D/Billboard.cpp
+++ b/T3D/T3D/Billboard.cpp
@@ -27,15 +27,22 @@ namespace T3D
 	
 	// Update the Billboard's facing every frame to ensure it's looking at the camera.
 	void Billboard::update(float dt){	
-		Vector3 target = camera->getWorldPosition();
+		Vector3 camera = this->camera->getWorldPosition();
 
 		if (lockY){
-			target.y = gameObject->getTransform()->getWorldPosition().y;
+			camera.y = gameObject->getTransform()->getWorldPosition().y;
 		}
 
-		gameObject->getTransform()->lookAt(target);
-		Quaternion q  = Quaternion::fromAngleAxis(-Math::HALF_PI, Vector3(1,0,0));
-		gameObject->getTransform()->rotate(q);
+		// Billboards require a 'special case' when using lookAt. 
+		// The lookAt matrix is defined with respect to the difference vector between the local and target transform, and an 'eye' (or camera) vector.
+		// When the camera is both the target _and_ the world-view camera in a right-hand coordinate system (i.e. OpenGL as in T3D), we need to compensate
+		// for the fact it is already 'looking down' the negative z axis, otherwise the XZ planemesh defining a billboard will be inverted.
+		auto *transform = gameObject->getTransform();
+		auto billboard_plane = transform->getWorldPosition();
+
+		transform->lookAt(billboard_plane - camera);
+		Quaternion q  = Quaternion::fromAngleAxis(Math::HALF_PI, Vector3(1,0,0));
+		transform->rotate(q);
 	}
 
 }

--- a/T3D/T3D/Mesh.cpp
+++ b/T3D/T3D/Mesh.cpp
@@ -16,30 +16,38 @@
 
 namespace T3D
 {
-
+	// Create a Mesh with initialised buffers and zero counts.
 	Mesh::Mesh(void)
 	{
-		vertices = NULL;
-		normals = NULL;
-		triIndices = NULL;
+		vertices    = NULL;
+		normals     = NULL;
+		triIndices  = NULL;
 		quadIndices = NULL;
-		colors = NULL;
-		uvs = NULL;
-		numVerts = 0;
-		numTris = 0;
-		numQuads = 0;
+		colors      = NULL;
+		uvs         = NULL;
+		numVerts    = 0;
+		numTris     = 0;
+		numQuads    = 0;
 	}
 
+	// Delete a Mesh's buffers with non-zero counts.
+	// If you are reading this from a Visual Studio breakpoint, you have probably
+	// trampled base pointers in adjacent memory during your mesh creation, causing
+	// the allocators delete[] buffer bookkeeping to be incorrect and it throws.
 	Mesh::~Mesh(void)
 	{
-		if (vertices) delete []vertices;
-		if (triIndices) delete []triIndices;
+		if (vertices)    delete []vertices;
+		if (triIndices)  delete []triIndices;
 		if (quadIndices) delete []quadIndices;
-		if (normals) delete []normals;
-		if (colors) delete []colors;
-		if (uvs) delete []uvs;
+		if (normals)     delete []normals;
+		if (colors)      delete []colors;
+		if (uvs)         delete []uvs;
 	}
 
+	// Initialises internal buffers (Vertex, Index, UV, etc) based on
+	// the number of vertices the caller requires to render primitives.
+	// For example, if you are creating a Cube out of Quads with flat (Gouraud) shading, 
+	// you would require 24 (4 * 6) vertices, 0 tris, and 6 quads.
 	void Mesh::initArrays(int numVerts, int numTris, int numQuads) {
 		this->numVerts = numVerts;
 		this->numTris = numTris;
@@ -81,6 +89,7 @@ namespace T3D
 		}
 	}
 
+	// Checks all internal buffers for erroneous values, logging relevant messages.
 	bool Mesh::checkArrays() {
 		bool ok = true;
 		for (int i = 0; i < numVerts; i++) {
@@ -111,46 +120,89 @@ namespace T3D
 		return ok;
 	}
 		
+	// Sets the ith vertex to have components x, y, z.
+	// Be careful to not mix up vertex counts and vertex indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	void Mesh::setVertex(int i, float x, float y, float z){
 		vertices[i*3] = x;
 		vertices[i*3+1] = y;
 		vertices[i*3+2] = z;
 	}
+
+	// Returns the ith vertex.
+	// Be careful to not mix up vertex counts and vertex indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	Vector3 Mesh::getVertex(int i){
 		return Vector3(vertices[i*3], vertices[i*3+1], vertices[i*3+2]);
 	}
+
+	// Sets the ith color to have components r, g, b, a
+	// Be careful to not mix up color counts and color indices, 
+	// as these are multiplied and divided out by 4 respectively.
 	void Mesh::setColor(int i, float r, float g, float b, float a){
 		colors[i*4] = r;
 		colors[i*4+1] = g;
 		colors[i*4+2] = b;
 		colors[i*4+3] = a;
 	}
+
+	// Returns the ith color.
+	// Be careful to not mix up color counts and color indices, 
+	// as these are multiplied and divided out by 4 respectively.
 	Vector4 Mesh::getColor(int i){
 		return Vector4(colors[i*4], colors[i*4+1], colors[i*4+2], colors[i*4+3]);
 	}
+
+	// Sets the ith normal to have components x, y, z.
+	// Does not attempt to normalize these components.
+	// Be careful to not mix up normal counts and normal indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	void Mesh::setNormal(int i, float x, float y, float z){
 		normals[i*3] = x;
 		normals[i*3+1] = y;
 		normals[i*3+2] = z;
 	}
+
+	// Sets the ith normal to the vector n.
+	// Does not check that the vector n is of unit length
+	// Be careful to not mix up normal counts and normal indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	void Mesh::setNormal(int i, Vector3 n){
 		normals[i*3] = n.x;
 		normals[i*3+1] = n.y;
 		normals[i*3+2] = n.z;
 	}
+
+	// Adds the vector n to the ith normal.
+	// Do not assume that the ith normal is of unit length after this call.
+	// Be careful to not mix up normal counts and normal indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	void Mesh::addNormal(int i, Vector3 n){
 		normals[i*3] += n.x;
 		normals[i*3+1] += n.y;
 		normals[i*3+2] += n.z;
 	}
+
+	// Returns the ith normal.
+	// Do not assume these are of unit length.
+	// Be careful to not mix up normal counts and normal indices, 
+	// as these are multiplied and divided out by 3 respectively.
 	Vector3 Mesh::getNormal(int i){
 		return Vector3(normals[i*3], normals[i*3+1], normals[i*3+2]);
 	}
+
+	// Sets the ith triFace to contain indices referring to vertices at positions a, b, c.
+	// It is up to you to get the winding order correct!
+	// Be careful to not mix up vertex and triangle indices for meshes containing both types of primitive.
 	void Mesh::setTriFace(int i, int a, int b, int c){
 		triIndices[i*3] = a;
 		triIndices[i*3+1] = b;
 		triIndices[i*3+2] = c;
 	}
+
+	// Sets the ith quadFace to contain indices referring to vertices at positions a, b, c, d.
+	// It is up to you to get the winding order correct!
+	// Be careful to not mix up vertex and quad indices for meshes containing both types of primitive.
 	void Mesh::setQuadFace(int i, int a, int b, int c, int d){
 		quadIndices[i*4] = a;
 		quadIndices[i*4+1] = b;
@@ -158,11 +210,17 @@ namespace T3D
 		quadIndices[i*4+3] = d;
 	}
 	
+	// Sets the ith UV index to have the components u, v.
 	void Mesh::setUV(int i, float u, float v){
 		uvs[i*2] = u;
 		uvs[i*2+1] = v;
 	}
 
+	// Calculate the normal vectors for each primitive that defines this mesh.
+	// *This sets each normal to be of unit length, i.e. normalized*. 
+	// It also clears memory to zero before calculating normals.
+	// Note that for non-planar quads there may be lighting defects. 
+	// This is especially noticable when using the Sweep class.
 	void Mesh::calcNormals(){
 		// set all normals to zero
 		for (int i=0; i<numVerts; i++){
@@ -196,14 +254,18 @@ namespace T3D
 		normalise();
 	}
 
+	// Reverse the direction of each normal, i.e. if pointing 'outwards', it now points 'inwards'.
+	// Preserve unit-length normals, but doesn't introduce normalization if they are not already unit length.
 	void Mesh::invertNormals(){
-		// set all normals to zero
 		for (int i=0; i<numVerts; i++){
 			Vector3 n = getNormal(i);
 			setNormal(i,-n.x,-n.y,-n.z);
 		}
 	}
 
+	// Calculate the UVs required to wrap a sphere of arbitrary density and radius.
+	// NOTE(Evan): To be consistent with the inheritance hierarchy, this should probably be a member function
+	// of the Sphere subclass as it's not useful for all meshes.
 	void Mesh::calcUVSphere(){		
 		for (int i=0; i<numVerts; i++){
 			Vector3 v = getVertex(i); 
@@ -212,51 +274,72 @@ namespace T3D
 		}
 	}
 
-	void Mesh::calcUVPlaneXY(){	
-		float maxX = 0;
-		float maxY = 0;
-		for (int i=0; i<numVerts; i++){
-			Vector3 v = getVertex(i); 
-			if (fabs(v.x)>maxX)
-				maxX = fabs(v.x);
-			if (fabs(v.y)>maxY)
-				maxY = fabs(v.y);
-		}
-		
-		for (int i=0; i<numVerts; i++){
-			Vector3 v = getVertex(i); 
-			setUV(i,v.x/maxX/2.0f+0.5f, v.y/maxY/2.0f+0.5f);
-		}
+	// Calculate the UVs required to wrap an XY plane of arbitrary width and height.
+	void Mesh::calcUVPlaneXY(){
+		uint32_t xOffset = offsetof(Vector3, x) / sizeof(float);
+		uint32_t yOffset = offsetof(Vector3, y) / sizeof(float);
+
+		calcUVPlane(xOffset, yOffset);
 	}
 
+	// Calculate the UVs required to wrap a YZ plane of arbitrary width and height.
 	void Mesh::calcUVPlaneYZ(){
+		uint32_t yOffset = offsetof(Vector3, y) / sizeof(float);
+		uint32_t zOffset = offsetof(Vector3, z) / sizeof(float);
+
+		calcUVPlane(yOffset, zOffset);
 	}
 
+	// Calculate the UVs required to wrap a YZ plane of arbitrary width and height.
 	void Mesh::calcUVPlaneXZ(){
-		float maxX = 0;
-		float maxZ = 0;
-		for (int i=0; i<numVerts; i++){
+		uint32_t xOffset = offsetof(Vector3, x) / sizeof(float);
+		uint32_t zOffset = offsetof(Vector3, z) / sizeof(float);
+
+		calcUVPlane(xOffset, zOffset);
+	}
+
+	// Internal helper function. Given two offsets into a Vector3 representing the planes of interest, 
+	// this function will find the min and max absolute values for each plane, then calculate and set 
+	// the UVs for each vertex with respect to the min and max.
+	// Assumes that 0 <= (vectorOffsetOne, vectorOffsetTwo) < 3.
+	void Mesh::calcUVPlane(uint32_t vectorOffsetOne, uint32_t vectorOffsetTwo)
+	{
+		assert(vectorOffsetOne < sizeof(Vector3) / sizeof(float));
+		assert(vectorOffsetTwo < sizeof(Vector3) / sizeof(float));
+
+		float maxP1 = 0; // Maximum for 1st plane
+		float maxP2 = 0; // Maximum for 2nd plane
+
+		for (int i = 0; i < numVerts; i++){
 			Vector3 v = getVertex(i); 
-			if (fabs(v.x)>maxX)
-				maxX = fabs(v.x);
-			if (fabs(v.z)>maxZ)
-				maxZ = fabs(v.z);
+			float absP1 = fabs(v[vectorOffsetOne]);
+			float absP2 = fabs(v[vectorOffsetTwo]);
+
+			maxP1 = std::max(absP1, maxP1);
+			maxP2 = std::max(absP2, maxP2);
 		}
 		
-		for (int i=0; i<numVerts; i++){
+		for (int i = 0; i < numVerts; i++){
 			Vector3 v = getVertex(i); 
-			setUV(i,v.x/maxX/2.0f+0.5f, v.z/maxZ/2.0f+0.5f);
+
+			float U = v[vectorOffsetOne] / maxP1 / 2.0f + 0.5f;
+			float V = v[vectorOffsetTwo] / maxP2 / 2.0f + 0.5f;
+
+			setUV(i, U, V);
 		}
 	}
 
-	void Mesh::calcUVCube(){
-	}
-
+	// Calculates and set every vertex normal to be unit length, i.e. normalized.
 	void Mesh::normalise(){
 		for (int i=0; i<numVerts; i++){
 			Vector3 v = getNormal(i);
 			v.normalise();
 			setNormal(i,v);
 		}
+	}
+
+	// UNIMPLEMENTED.
+	void Mesh::calcUVCube(){
+		printf("WARNING\n\t`calcUVCube()` is unimplemented!\n");
 	}
 }

--- a/T3D/T3D/Mesh.h
+++ b/T3D/T3D/Mesh.h
@@ -20,7 +20,10 @@ namespace T3D
 	class Mesh : public Component
 	{
 	public:
+		// Create a Mesh with initialised buffers and zero counts.
 		Mesh(void);
+
+		// Delete a Mesh's buffers with non-zero counts.
 		virtual ~Mesh(void);
 
 		// Accessors.
@@ -36,7 +39,7 @@ namespace T3D
 
 
 
-		// Initialises internal Vertex, Index and Colour buffers based on
+		// Initialises internal buffers (Vertex, Index, UV, etc) based on
 		// the number of vertices the caller requires to render primitives.
 		void initArrays(int numVerts, int numTris, int numQuads);
 
@@ -71,6 +74,7 @@ namespace T3D
 		virtual void    setQuadFace(int i, int a, int b, int c, int d);
 		virtual void    setUV(int i, float u, float v);
 
+
 	protected:
 		int numVerts, numTris, numQuads;
 
@@ -81,6 +85,9 @@ namespace T3D
 
 		unsigned int *triIndices;
 		unsigned int *quadIndices;
+
+	private:
+		void calcUVPlane(uint32_t vectorOffsetOne, uint32_t vectorOffsetTwo);
 	};
 }
 

--- a/T3D/T3D/T3DTest.cpp
+++ b/T3D/T3D/T3DTest.cpp
@@ -29,18 +29,9 @@
 #include "Sweep.h"
 #include "SweepPath.h"
 
-namespace T3D{
+namespace T3D {
 
-	T3DTest::T3DTest(void)
-	{
-	}
-
-
-	T3DTest::~T3DTest(void)
-	{
-	}
-
-	bool T3DTest::init(){
+	bool T3DTest::init() {
 		// Call init of superclass (sets up sdl and opengl)
 		WinGLApplication::init();
 

--- a/T3D/T3D/T3DTest.h
+++ b/T3D/T3D/T3DTest.h
@@ -19,8 +19,8 @@ class T3DTest :
 	public WinGLApplication
 {
 public:
-	T3DTest(void);
-	~T3DTest(void);
+	T3DTest(void)  = default;
+	~T3DTest(void) = default;
 
 	bool init();
 };


### PR DESCRIPTION
## Notable changes

### Billboards
* Fix mirrored billboard transform by compensating for right-handedness before calling `lookAt()`. Running the original `T3DTest` has 'Hello World' mirrored due to this error, which this fixes

### Mesh
* All public functions are documented, especially with respect to common misuse (e.g. invalid indices, non-unit-length normals)
* The `calcUVPlane(XY|XZ|YZ|` functions have been refactored to not copy-paste a nearly identical calculation throughout, while retaining the same public interface. They now call into an internal `calcUVPlane()` function. *Note that this also implements `calcUVPlaneXY()`, which was never implemented previously and is thus untested, but should work.*
* `calcUVCube()` is marked explicitly as unimplemented, and logs that fact. I believe this function is implemented in the tutorial on textures.

### T3DTest
Add a default constructor and destructor. 