### PR TITLE
T3D builds in release mode!

### DIFF
--- a/T3D/T3D/T3D.vcxproj
+++ b/T3D/T3D/T3D.vcxproj
@@ -159,6 +159,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <LibraryPath>..\Lib;$(LibraryPath)</LibraryPath>
+    <SourcePath>$(SourcePath)</SourcePath>
+    <IncludePath>..\Include;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -193,8 +196,11 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>legacy_stdio_definitions.lib;opengl32.lib;glu32.lib;glew32.lib;SDL_ttf.lib;glew32mx.lib;glew32s.lib;glew32mxs.lib;sdl.lib;sdlmain.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>legacy_stdio_definitions.lib;opengl32.lib;glu32.lib;glew32.lib;SDL_ttf.lib;SDL_image.lib;glew32mx.lib;glew32s.lib;glew32mxs.lib;sdl.lib;sdlmain.lib;fmodex_vc.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "$(SolutionDir)lib\*.dll" "$(TargetDir)" /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Basically, this changes copies over debug post-build hooks, linker settings and include dirs to the release mode's configuration.
**Note that this will *probably* expose a myriad of optimization-related bugs**. Which isn't a _bad_ thing if the code is incorrect in the first place and is isolated to that particular build mode.
For example, I noticed that the skybox can disappear sometimes after a few seconds in this compilation mode. 
That's never happened to me in debug builds before (including during this change).

Regardless, this is a small and useful addition!