### PR TITLE
Document T3D, tidy headers, instrument application logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,7 +336,7 @@ paket-files/
 
 # JetBrains Rider
 .idea/
-*.sln.iml
+*.sln.imlG
 
 # CodeRush
 .cr/
@@ -366,3 +366,8 @@ __pycache__/
 
 *.msp
 
+# T3D specific
+T3D_Log.txt
+perflog.txt
+
+Doxyfile

--- a/T3D/T3D/Animation.cpp
+++ b/T3D/T3D/Animation.cpp
@@ -6,68 +6,103 @@
 //
 // Animation.cpp
 //
-// A component for controlling skeletal animation.
+// A component for controlling rigid skeletal animation.
 
-#include "animation.h"
+#include "Animation.h"
 #include "GameObject.h"
 #include "Math.h"
+#include "Logger.h"
 
 namespace T3D
 {
-	// Create an animation of length `duration`. 
-	// Does _not_ play or loop by default.
+	/*!
+	 * \param duration The maximum time of the animation
+	 *
+	 * \note Does not start playing or looping by default!
+	 */
 	Animation::Animation(float duration) : duration(duration),
 										   time(0),
 										   looping(false),
 										   playing(false) { }
 
+	/*!
+	 * Integrates the change in time from the current keyframe to the next.
+	 * \param dt Change in time
+	 */
+	void Animation::update(float dt){		
+		if (!playing) return;
 
-	// Adds a named keyframe describing a rotation and position beginning at a provided timestep.
-	// NOTE(Evan): This is incorrect if the provided time is outside the animation's range.
-	//             Should this be clamped to the animation's range and logged?
-	void Animation::addKey(std::string n, float time, Quaternion rot, Vector3 pos){
-		BoneMap::iterator it = bones.find(n);
-
-		if(it == bones.end())
-		{
-		   addBone(n);
+		time += dt;
+		if (time > duration) {
+			if (looping) {
+				time = fmod(time, duration);
+			} else {
+				time = duration;
+				playing = false;
+			}
 		}
-
-		KeyFrame f = {time,rot,pos};
-		bones[n]->addFrame(f);
+		for (auto &bone: bones){
+			bone.second->update(time);
+		}
 	}
 
-	// Adds a bone to the parent game object.
+	/*!
+	 * \param n Name of the transform to add the bone to
+	 *
+	 * \note Issues a warning if a child Transform with name `n` does not exist 
+	 */
 	void Animation::addBone(std::string n)
 	{
-		Bone *b = new Bone();
-		b->transform = gameObject->getTransform()->getAncestorByName(n);
-		if (b->transform!=NULL){
-			bones.insert(BoneEntry(n,b));
+		auto parent = gameObject->getTransform()->getAncestorByName(n);
+		if (parent) {
+			auto bone = new Bone();
+			bone->transform = parent;
+			bones.insert(BoneEntry(n, bone));
+
+			logger::Log(priority::Tracing, output_stream::File, category::Animation, "Added bone to parent %s", n.c_str());
 		} else {
-			std::cout << "ERROR: bone not found in addBone(" << n << ")\n)";
+			logger::Log(priority::Warning, output_stream::All, category::Animation, "Bone not found in addBone: %s", n.c_str());
 		}
 	}
 
-	// Integrate the change in time `dt` to the animation's state.
-	// Looping animations are reset to the beginning, and non-looping animations are flagged as finished.
-	void Animation::update(float dt){		
-		if (playing){
-			time += dt;
-			if (time>duration){
-				if (looping){
-					while (time>duration)
-						time = time-duration;
-				} else {
-					time = duration;
-					playing = false;
-				}
-			}
-			BoneMap::iterator it;
-			for (it = bones.begin(); it!= bones.end(); it++){
-				Bone *b = it->second;
-				b->update(time);
-			}
+	/*!
+	 * Positions in between each timestep are linearly interpolated, and orientations are spherically interpolated.
+	 *
+	 * \param n Name of `Transform` 
+	 * \param time Time in seconds 
+	 * \param pos Orientation at `time`
+	 * \param pos Local position at `time`
+	 *
+	 * \note This will issue a warning if the time provided is outside the animation range; it will *not* clamp the time.
+	 */
+	void Animation::addKey(std::string n, float time, Quaternion rot, Vector3 pos){
+		if (time > duration)
+		{
+			logger::Log(priority::Warning, 
+						output_stream::All, 
+						category::Animation, 
+						"Keyframe %s has time [%.3fs], which is outside animation duration [%.3fs]!",
+						n.c_str(),
+						time,
+						duration);
+		}
+
+		/* If there's no string key associated with the bone, add it to the map first,
+		   otherwise std::map operator[] will insert default constructed (empty) key with the bone */
+		if (bones.find(n) == bones.end()) addBone(n);
+
+		bones[n]->addFrame(KeyFrame { time, rot, pos });
+	}
+
+	/*!
+	 * \note This requires the `logger` to be initialized at the application's beignning, e.g. outside the `WinGLApplication` loop body, to work properly.
+	 */
+void Animation::printFrames()
+	{
+		logger::Log(priority::Tracing, output_stream::Console, category::Animation, "Animation Dump");
+		for (auto &bone : bones){
+			logger::Log(priority::Tracing, output_stream::Console, category::Animation, "Bone : %s", bone.first.c_str());
+			bone.second->printKeyFrames();
 		}
 	}
 }

--- a/T3D/T3D/Animation.h
+++ b/T3D/T3D/Animation.h
@@ -6,66 +6,83 @@
 //
 // Animation.cpp
 //
-// A component for controlling skeletal animation.
-
-#ifndef ANIMATION_H
-#define ANIMATION_H
+// A component for controlling rigid skeletal animation.
+#pragma once
 
 #include <vector>
 #include <list>
 #include <string>
 #include <map>
-#include <iostream>
-#include "component.h"
+
+#include "Component.h"
 #include "Transform.h"
 #include "Vector3.h"
+#include "Quaternion.h"
 #include "Bone.h"
 
 namespace T3D
 {
-	typedef std::pair<std::string,Bone*> BoneEntry;
-	typedef std::map<std::string,Bone*> BoneMap;
+	//! \brief The name of a Transform joint and its a Bone.
+	typedef std::pair<std::string, Bone*> BoneEntry;
+	//! \brief An associative container that maps the name of a Transform joint to a Bone.
+	typedef std::map<std::string, Bone*> BoneMap;
 
+	//! \brief Animation component. Ticks every frame until completion, updating a rigid skeletal hierarchy of `Bone`s associated with an `GameObject`.
+	/*!
+	 *	This class is just one way to implement an Animation. An alternative is to subclass `Task`, which allows for a more centralized way to manage multiple objects,
+	 *  or even multiple Animations.
+	 */
 	class Animation :
 		public Component
 	{
 	public:
-		// Create an animation of length `duration`. 
-		// Does not play or loop by default.
+		//! \brief Create an animation of `duration` seconds length.
 		Animation(float duration);
+
+		//! \brief Destroy the animation.
 		virtual ~Animation() = default;
+
+		//! \brief Tick the animation by integrating the change in time.
 		virtual void update(float dt);
 
-		// Adds a bone to the parent game object.
+		//! \brief Adds a bone to the parent game object.
 		void addBone(std::string n);
 
-		// Adds a named keyframe describing a rotation and position beginning at a provided timestep.
+		//! \brief Adds a keyframe to a named transform, describing a rotation and position at a timestamp.
 		void addKey(std::string n, float time, Quaternion rot, Vector3 pos);
 
-		// Runtime helper functions.
-		void play()          { time = 0; playing = true; }
-		void pause()         { playing = false;          }
-		void loop(bool loop) { looping = loop;           } 
+		//! \brief Log all keyframes for the animation to the console.
+		void printFrames();
 
-		// Log all keyframes for the animation.
-		void printFrames() {
-            std::cout << "Animation:\n";
-			BoneMap::iterator it;
-			for (it = bones.begin(); it!= bones.end(); it++){
-				std::cout << "bone: " << it->first << "\n";
-				Bone *b = it->second;
-				b->printKeyFrames();
-			}
-        }
+
+		// Runtime helper functions. Inlined to the header because they're so small.
+
+
+		//! \brief Start playing the animation, resetting its time.
+		void play() { time = 0; playing = true; }
+
+		//! \brief Pause the animation from updating. 
+		void pause() { playing = false; }
+
+		//! \brief Set the animation to loop.
+		/*!
+		 *
+		 * \param loop New loop state
+		 * \note If a non-looping animation has finished, this will effectively reset it to beginning, _then_ start playing.
+		 */
+		void loop(bool loop) { looping = loop; } 
+
 
 	protected:
+		//! \brief associative container, between named transforms and bones
 		BoneMap bones;
+		//! \brief how long the animation shall go for
 		float   duration;
+		//! \brief the animation's current time
 		float   time;
+		//! \brief the animation's current playing state
 		bool    playing;
+		//! \brief is the animation looping
 		bool    looping;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Billboard.cpp
+++ b/T3D/T3D/Billboard.cpp
@@ -11,13 +11,13 @@
 
 #include "Billboard.h"
 #include "PlaneMesh.h"
-#include "GameObject.h"
-#include "T3DApplication.h"
-#include "Camera.h"
 
 namespace T3D
 {
-	// Initialise the Billboard component with its parent GameObject.
+	/*!
+	 * \param go GameObject associated with this component. 
+	 * \note If no GameObject is associated with the Billboard, then `update` won't ever tick!
+	*/
 	void Billboard::init(GameObject* go){
 		gameObject = go;
 		
@@ -25,16 +25,18 @@ namespace T3D
 		gameObject->setMesh(mesh);
 	}
 	
-	// Update the Billboard's facing every frame to ensure it's looking at the camera.
+	/*!
+	 * \param dt Change in time
+	 *
+	 * \note This assumes a right-handed coordinate system like OpenGL is being used!
+	 */
 	void Billboard::update(float dt){	
 		Vector3 camera = this->camera->getWorldPosition();
 
-		if (lockY){
-			camera.y = gameObject->getTransform()->getWorldPosition().y;
-		}
+		if (lockY) camera.y = gameObject->getTransform()->getWorldPosition().y;
 
 		// Billboards require a 'special case' when using lookAt. 
-		// The lookAt matrix is defined with respect to the difference vector between the local and target transform, and an 'eye' (or camera) vector.
+		// The lookAt matrix is defined with respect to the difference between the local and target transform and the camera.
 		// When the camera is both the target _and_ the world-view camera in a right-hand coordinate system (i.e. OpenGL as in T3D), we need to compensate
 		// for the fact it is already 'looking down' the negative z axis, otherwise the XZ planemesh defining a billboard will be inverted.
 		auto *transform = gameObject->getTransform();

--- a/T3D/T3D/Billboard.h
+++ b/T3D/T3D/Billboard.h
@@ -8,37 +8,55 @@
 //
 // A billboard component.  Creates a plane mesh and adds it to the game object.  
 // Update method supports spherical and cylindrical billboarding to face the plane towards the camera
+#pragma once
 
-#ifndef BILLBOARD_H
-#define BILLBOARD_H
-
-#include "component.h"
+#include "GameObject.h"
+#include "Component.h"
 #include "Transform.h"
 
 namespace T3D
 {
+	//! \brief Billboard is a wrapper around a plane mesh. Every frame, the billboard will face the camera.
+	/*!
+	 *	You will want to add a Billboard to a GameObject that has a textured `Material`, otherwise it won't be very exciting, or visible.
+	 */
 	class Billboard :
 		public Component
 	{
 	public:
-		// Creates a Billboard associated with a Camera. May rotate about the Y axis by default.
-		// A Billboard should be initialised with a parent GameObject using its init method before it can be used.
+
+		//! \brief Creates a Billboard associated with a Camera. May rotate about the Y axis by default.
+		/*!
+		 * \param camera	Camera billboard should face
+		 * \param lockY		Can the billboard move about the Y axis? ('yaw')
+		 *
+		 * \note A Billboard should be initialised with a parent GameObject using its init method before it can be used.
+		 */
 		Billboard(Transform* camera, bool lockY = false) : lockY(lockY),
 		                                                   camera(camera) { };
+		//! \brief Destroy the billboard.
 		~Billboard(void) = default;
 
-		// Update the Billboard's facing every frame to ensure it's looking at the camera.
+		//! \brief Update the Billboard's facing every frame to ensure it's looking at the camera.
 		virtual void update(float dt);
+
+		//! \brief Destroy the billboard.
 		virtual void init(GameObject* go);
 
-		// Helper functions.
+		// Helper functions. Inlined because they're so small.
+
+
+		//! \brief Set the Y axis to be locked.
 		void lockYAxis()  { lockY = true; }
+
+		//! \brief Set the Y axis to be unlocked.
 		void unlockYAxis(){ lockY = false; }
 
 	private:
+		//! \brief Transform of the Camera to face
 		Transform* camera;
+
+		//! \brief Can the billboard move about the Y axis?
 		bool lockY;
 	};
 }
-
-#endif

--- a/T3D/T3D/Bone.h
+++ b/T3D/T3D/Bone.h
@@ -7,15 +7,14 @@
 // Bone.h
 //
 // Bone class used for animation in conjunction with the Animation class
-
-#ifndef BONE_H
-#define BONE_H
+#pragma once
 
 #include <vector>
 #include "Transform.h"
 
 namespace T3D
 {
+	//! \brief A rotation and position associated with a timestamp in seconds.
 	struct KeyFrame
 	{
 		float time;
@@ -23,23 +22,30 @@ namespace T3D
 		Vector3 position;
 	};
 
+	//! \brief Bones manage a collection of `KeyFrame`s associated with a named `Transform`, updating the `Transform` recursively every tick.
 	class Bone
 	{
 	public:
+		//! \brief Create a `Bone`.
 		Bone(void) = default;
+
+		//! \brief Destroy a `Bone`.
 		~Bone(void) = default;
 
+		//! \brief Update the `Bone`'s position by interpolating between the current and next keyframes.
 		void update(float time);
+
+		//! \brief Add a `KeyFrame` to the `Bone`. 
 		void addFrame(KeyFrame f);
 
-		// Dump information for this bone to standard output.
+		//! \brief Dump information for this `Bone` to standard output.
 		void printKeyFrames();
 
-		// Accessed by Animation.
+		//! \brief The `Transform` parent this `Bone` manipulates.
 		Transform* transform = NULL;
+
+		//! \brief The collection of `KeyFrame`s associated with the Bone.
+		// \note _This_ is ordered, even if keyframes can be added in arbitrary sequences.
 		std::vector<KeyFrame> keyframes;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Camera.cpp
+++ b/T3D/T3D/Camera.cpp
@@ -9,12 +9,18 @@
 // Simple camera class to be attached to GameObject(s) and referenced from Renderer
 
 #include "Camera.h"
-#include "Plane.h"
-#include "GameObject.h"
+#include "Logger.h"
 
 namespace T3D
 {
-	// constructor with perspective parameters
+	/*!
+	 * \param near Near clip plane distance. If <= 0, a warning is issued.
+	 * \param far Far clip plane distance.
+	 * \param fovy Field of view spanning 'y' in *degrees*.
+	 * \param aspect Aspect ratio. Most monitors are 16:9, so (16.0/9.0) works.
+	 *
+	 * \note The ratio between near and far should be kept small. The depth buffer of a scene is non-linear so it will lose a lot of precision over distances with a very small near clip plane. The near plane should be as far away from 0 as possible. 
+	 */
 	Camera::Camera(double near, double far, double fovy, double aspect) : Component()
 	{
 		this->type = Camera::Type::PERSPECTIVE;
@@ -31,12 +37,25 @@ namespace T3D
 
 		if (near <= 0.0)
 		{
-			std::cout << "Camera's near clip plane is 0 or less " << near << std::endl;
-			// TODO(Evan): Log!
+			logger::Log(priority::Warning, 
+						output_stream::File, 
+						category::Video, 
+						"Camera's near clip plane is 0 or less! Near: %.4f\n"
+						,
+						near);
 		}
 	}
 
-	// constructor with orthographic parameters
+	/*!
+	 * \param near Near clip plane distance. If <= 0, a warning is issued.
+	 * \param far Far clip plane distance.
+	 * \param left Left plane of frustrum
+	 * \param right Right plane of frustrum
+	 * \param bottom Bottom plane of frustrum
+	 * \param top Top plane of frustrum
+	 *
+	 * \note The ratio between near and far should be kept small. The depth buffer of a scene is non-linear so it will lose a lot of precision over distances with a very small near clip plane. The near plane should be as far away from 0 as possible. 
+	 */
 	Camera::Camera(double near, double far, double left, double right, double bottom, double top) : Component()
 	{
 		this->type = Camera::Type::ORTHOGRAPHIC;
@@ -47,9 +66,19 @@ namespace T3D
 		this->bottom = bottom;
 		this->top = top;
 
-		/* Zeroed perspective parameters */
+		/* Default perspective parameters */
 		this->fovy   = 0;
 		this->aspect = 1.0f;
+
+		if (near <= 0.0)
+		{
+			logger::Log(priority::Warning, 
+						output_stream::File, 
+						category::Video, 
+						"Camera's near clip plane is 0 or less! Near: %.4f\n"
+						,
+						near);
+		}
 	}
 
 }

--- a/T3D/T3D/Camera.h
+++ b/T3D/T3D/Camera.h
@@ -7,28 +7,31 @@
 // camera.h
 //
 // Simple camera class to be attached to GameObject(s) and referenced from Renderer
-
-#ifndef CAMERA_H
-#define CAMERA_H
+#pragma once
 
 #include "Component.h"
-#include "Plane.h"
-#include "Transform.h"
 
 namespace T3D
 {
+	//! \brief A camera for viewing the scene. Can be perspective or orthographic.
+	/*!
+	 *	Camera's are associated with a GameObject, like all Components. An idiom in T3D is to attach a Camera and KeyboardController component to a GameObject to act as a fly camera.
+	 */
 	class Camera :
 		public Component
 	{
 	public:
+
+		//! \brief What type of Camera an instance is
 		enum class Type 
 		{
 			PERSPECTIVE,
 			ORTHOGRAPHIC
 		};
 
-		// Safe default perspective camera
-		Camera::Camera() : type      (Camera::Type::PERSPECTIVE),
+		//! \brief Create a perspective camera with safe defaults.
+		Camera::Camera() : Component(), 
+						   type      (Camera::Type::PERSPECTIVE),
 						   near      (0.1),
 						   far       (500.0),
 						   fovy      (45.0),
@@ -39,28 +42,33 @@ namespace T3D
 						   top       (0)
 		{ }
 
-		// Perspective Camera
+		//! \brief Create a perspective camera.
 		Camera(double near, double far, double fovy, double aspect);
-		// Orthographic Camera
+
+		//! \brief Create an orthographic camera.
 		Camera(double near, double far, double left, double right, double bottom, double top);
 
+		//! \brief Destroy the camera.
 		virtual ~Camera() = default;
 
 	public:
-		Type type;	// projection type
+		//! \brief Projection type
+		Camera::Type type;
 
-		double far;				// far z plane (distance from viewer)
-		double near;			// near Z plane (distance from viewer)
+		//! \brief far Z plane (distance from viewer)
+		double far;				
+		//! \brief near Z plane (distance from viewer)
+		double near;
 
-		// Perspective projection only
-		double fovy;			// field of view (angle in degrees)
-		double aspect;			// field of view in X direction - ratio of x(width) to y(height)
+		/* Perspective projection only */
+		//! \brief field of view (angle in degrees)
+		double fovy;
+		//! \brief field of view in X direction - ratio of x(width) to y(height)
+		double aspect;
 
-		// Orthographic only
-		double left,right,top,bottom;	// view extent
+		/* Orthographic only */
+		//! \brief planes of view extent/frustrum 
+		double left, right, top, bottom;
 
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Colour.cpp
+++ b/T3D/T3D/Colour.cpp
@@ -8,8 +8,6 @@
 //
 // Simple colour class
 
-#include "Colour.h"
-
 namespace T3D
 {
 	/* Plain old data class : Implementation inside header */ 

--- a/T3D/T3D/Colour.h
+++ b/T3D/T3D/Colour.h
@@ -7,21 +7,20 @@
 // Colour.h
 //
 // Simple colour class
-
-#ifndef COLOUR_H
-#define COLOUR_H
+#pragma once
 
 #include <stdint.h>
 
 namespace T3D
 {
+	//! \brief A simple Colour class, where colour channels and alpha are integers ranging 0-255.
 	class Colour
 	{
 	public:
-		// Create a Colour from 'rgba' components.
-		// _Assumes 0 > (r|g|b|a) > 255_.
-		Colour(int r, int g, int b, int a) : r(r), b(b), g(g), a(a){}
+		//! \brief Create Colour (trivially)
+		Colour(int r, int g, int b, int a) : r(r), b(b), g(g), a(a) { }
 
+		//! \brief Create Colour from a 32-bit dword. 
 		Colour(uint32_t hex){
 			r = (hex >> 24) & 0xff;
 			g = (hex >> 16) & 0xff;
@@ -29,11 +28,9 @@ namespace T3D
 			a = hex & 0xff;
 		}
 
+		//! \brief Destroy Colour (trivially)
 		~Colour(void) = default;
 
 		int r,g,b,a;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Component.cpp
+++ b/T3D/T3D/Component.cpp
@@ -10,9 +10,6 @@
 // Used to add behaviours and other functionality to game objects
 // Automatically updated by application
 
-#include "Component.h"
-#include "GameObject.h"
-
 namespace T3D
 {
 	/* Abstract class : Implementation not provided */ 

--- a/T3D/T3D/Component.h
+++ b/T3D/T3D/Component.h
@@ -9,26 +9,32 @@
 // Abstract component class for game objects
 // Used to add behaviours and other functionality to game objects
 // Automatically updated by application
-
-#ifndef COMPONENT_H
-#define COMPONENT_H
+#pragma once
 
 namespace T3D
 {
 	class GameObject;
 
+	//! \brief Components are used to add functionality (or behaviour) to GameObjects, using a 'has-a' relationship. A GameObject can have zero or more components.
 	class Component
 	{
 	public:
+		//! \brief Create a Component.
 		Component(void) : gameObject(nullptr) { }
+
+		//! \brief Destroy a Component.
 		virtual ~Component(void) = default;
 
+		//! \brief Tick the Component.
 		virtual void update(float dt)     { /* overridden */ };
+
+		//! \brief Initialize the Component to be associated with a GameObject.
+		/*!
+		 * \param go GameObject to associate with this component. 
+		 */
 		virtual void init(GameObject* go) { gameObject = go; };
 
-	public:
+		//! \brief GameObject that 'has' this Component
 		GameObject *gameObject;
 	};
 }
-
-#endif

--- a/T3D/T3D/Cube.h
+++ b/T3D/T3D/Cube.h
@@ -8,24 +8,23 @@
 //
 // Simple cube mesh with coloured sides
 
-#ifndef CUBE_H
-#define CUBE_H
-
-#include "mesh.h"
+#pragma once
+#include "Mesh.h"
 
 namespace T3D
 {
+	//! \brief A simple parametric Cube Mesh.
 	class Cube :
 		public Mesh
 	{
 	public:
-		// Create a cube with volume = size^3.
+		//! \brief Create Cube with volume = `size^3`.
 		Cube(float size);
 
-		// Mesh deletes arrays if they have been created, not need to do anything here
+		//! \brief Destroy Cube.
+		/*! \note Mesh superclass deletes arrays if they have been created, no need to do anything here
+		*/
 		virtual ~Cube(void) = default;
 	};
 }
-
-#endif
 

--- a/T3D/T3D/DefaultDebugOptions.h
+++ b/T3D/T3D/DefaultDebugOptions.h
@@ -8,26 +8,44 @@
 //
 // Set default debug options. Applied when starting a WinGLApplication
 #pragma once
+#include <stdint.h>
 
 namespace T3D
 {
+	//! \brief A class wrapping a handful of static data members.
 	class DefaultDebugOptions
 	{
 	public:
-		// Renderer constants.
-		
+		static const uint32_t DefaultWindowWidth = 1024u;
+
+		static const uint32_t DefaultWindowHeight = 640u;
 		// Visualization toggles
+
+		//! \brief Show wireframe on startup
 		static const bool showWireframe = false;  // F1
+
+		//! \brief Show world axes on startup
 		static const bool showAxes		= false;  // F2
+
+		//! \brief Show mesh grid lines on startup
 		static const bool showGrid		= false;  // F3
+
+		//! \brief Show mesh points on startup
 		static const bool showVertices	= false;  // F4
 
 
 		// KeyboardController constants
-		// Key and Mouse min/max
-		static constexpr float keySensitivityMin   = 50.0;
-		static constexpr float keySensitivityMax   = 100.0;
+
+		//! \brief Movement speed when acceleration key (`Shift` by default) isn't held
+		static constexpr float keySensitivityMin   = 50.0f;
+
+		//! \brief Movement speed when acceleration key (`Shift` by default) is held
+		static constexpr float keySensitivityMax   = 100.0f;
+
+		//! \brief Rotational speed when acceleration key (`Shift` by default) isn't held
 		static constexpr float mouseSensitivityMin = 0.0005f;
+
+		//! \brief Rotational speed when acceleration key (`Shift` by default) is held
 		static constexpr float mouseSensitivityMax = 0.0010f;
 	};
 }

--- a/T3D/T3D/DiagMessageTask.cpp
+++ b/T3D/T3D/DiagMessageTask.cpp
@@ -8,38 +8,102 @@
 //
 // Onscreen diagnostic/debug messages
 
-#include <sstream>
-#include <fstream>
+#include <algorithm> // std::max
+
 #include "DiagMessageTask.h"
+#include "Colour.h"
+#include "Texture.h"
+#include "Logger.h"
+#include "Renderer.h"
+#include "GLRenderer.h"
+#include "Font.h"
 
-namespace T3D{
+namespace T3D {
 
+	/*
+	 * \param app Application root
+	 */
 	DiagMessageTask::DiagMessageTask(T3DApplication *app) : Task(app)
 	{		
 		setName("DiagMessageTask");
-		refresh = false;
-
-		this->timed = false;
-
+		refresh     = false;
+		timed       = false;
 		diagOverlay = NULL;
+		logger::Log(priority::Info, output_stream::All, category::Task, "Initialised persistent DiagMessageTask");
 	}
 
+	/*
+	 * \param Application root
+	 * \param message text to display, assumed null-terminated c-string (i.e. what std::string::c_str() provides)
+	 * \param x Leftmost x coordinate the message shall start, in pixels.
+	 * \param x Upper y coordinate the message shall start, in pixels. Note that `y_max` is at the top of the screen
+	 * \param timed Does the message have a duration?
+	 * \param duration Duration in seconds
+	 */
 	DiagMessageTask::DiagMessageTask(T3DApplication *app, const char *message, int x, int y, bool timed, float duration) : Task(app)
 	{		
 		setName("DiagMessageTask");
 
 		this->timed = timed;
-		this->time = duration;
+		time = duration;
 
 		setMessage(message, x, y);
 
 		diagOverlay = NULL;
+		logger::Log(priority::Tracing, output_stream::All, category::Task, "Initialised timed DiagMessageTask");
 	}
-
 
 	DiagMessageTask::~DiagMessageTask(void)
 	{
 		removeOverlay();
+		logger::Log(priority::Tracing, output_stream::All, category::Task, "End DiagMessageTask");
+	}
+
+	/*
+	 * \param dt Change in time
+	 * \note If this function is not working, it's probably a font error, but it could also be a hard-coded screen coordinate. Check `T3D_Log.txt`.
+	 */
+	void DiagMessageTask::update(float dt){
+		if (timed)
+		{
+			time -= dt;
+			if (time < 0.0f) setFinished(true);
+		}
+
+		if (refresh)
+		{
+			removeOverlay();
+
+			font *f = app->getFont("Resources/FreeSans.ttf", 16);
+			if (f)
+			{
+				if (!diagOverlay) {
+					// Create and add overlay
+					int w = app->getRenderer()->WindowWidth; // texture width, should be large enough for most diagnostics
+					int h = 32;	// should be enough for single line (text wrap is not supported)
+
+					diagOverlay = new Texture(w,h);
+
+					diagOverlay->clear(Colour(0,0,0,255));
+					diagOverlay->writeText(0, 0, message.c_str(), Colour(255,255,255,255), f->getFont());
+					app->getRenderer()->loadTexture(diagOverlay, false);			// load new texture in renderer
+					app->getRenderer()->add2DOverlay(diagOverlay, x, y);			// add to renderer overlays
+
+					logger::Log(priority::Tracing, 
+								output_stream::File, 
+								category::Task, 
+								"Created overlay for DiagMessageTask");
+				}
+				else 
+				{
+					// refresh overlay
+					diagOverlay->clear(Colour(0,0,0,255));
+					diagOverlay->writeText(0, 0, message.c_str(), Colour(255,255,255,255), f->getFont());
+					app->getRenderer()->reloadTexture(diagOverlay);					// reload texture in renderer
+				}
+			}
+		}
+
 	}
 
 	void DiagMessageTask::removeOverlay()
@@ -56,6 +120,11 @@ namespace T3D{
 		}
 	}
 
+	/*
+	 * \param message new text to display. Assumed null-terminated c-string.
+	 * \param x new x coordinate
+	 * \param y new y coordinate. Note that 'Y_max' is the top of the screen in T3D.
+	 */
 	void DiagMessageTask::setMessage(const char *message, int x, int y){
 		this->message = message;
 		this->x = x;
@@ -63,48 +132,13 @@ namespace T3D{
 		refresh = true;
 	}
 
+	/*
+	 * \param duration New duration
+	 */
 	void DiagMessageTask::setTimed(float duration)
 	{
 		timed = true;
 		time = duration;
-	}
-
-	void DiagMessageTask::update(float dt){
-		if (timed)
-		{
-			time -= dt;
-			if (time < 0.0f)
-				setFinished(true);
-		}
-
-		if (refresh)
-		{
-
-			removeOverlay();
-
-			font *f = app->getFont("resources/FreeSans.ttf", 16);
-			if (f != NULL)
-			{
-				if (diagOverlay == NULL) {
-					// Create and add overlay
-					int w = 1024;		// texture width, should be large enough for most diagnostics
-					int h = 32;			// should be enough for single line (text wrap is not supported)
-					diagOverlay = new Texture(w,h);
-
-					diagOverlay->clear(Colour(0,0,0,255));
-					diagOverlay->writeText(0, 0, message.c_str(), Colour(255,255,255,255), f->getFont());
-					app->getRenderer()->loadTexture(diagOverlay, false);			// load new texture in renderer
-					app->getRenderer()->add2DOverlay(diagOverlay, x, y);			// add to renderer overlays
-				}
-				else {
-					// refresh overlay
-					diagOverlay->clear(Colour(0,0,0,255));
-					diagOverlay->writeText(0, 0, message.c_str(), Colour(255,255,255,255), f->getFont());
-					app->getRenderer()->reloadTexture(diagOverlay);					// reload texture in renderer
-				}
-			}
-		}
-
 	}
 
 }

--- a/T3D/T3D/DiagMessageTask.h
+++ b/T3D/T3D/DiagMessageTask.h
@@ -8,26 +8,45 @@
 //
 // Onscreen diagnostic/debug messages
 
-#ifndef DIAGMESSAGETASK_H
-#define DIAGMESSAGETASK_H
+#pragma once
 
-#include "task.h"
+#include "Task.h"
 
-namespace T3D{
+namespace T3D 
+{
+
+	class Texture;
+
+	//! \brief Class providing timed on-screen diagnostic messages.
 	class DiagMessageTask :
 		public Task
 	{
 	public:
+		//! \brief Create DiagMessageTask that is hidden and not timed by default.
 		DiagMessageTask(T3DApplication *app);
-		DiagMessageTask(T3DApplication *app, const char *message, int x, int y, bool timed=false, float duration=0.0f);
+
+		//! \brief Create a DiagMessageTask with parameters.
+		DiagMessageTask(T3DApplication *app, 
+						const char *message, 
+						int x, 
+						int y, 
+						bool timed = false, 
+						float duration = 0.0f);
+
+		//! \brief Destroy DiagMessageTask
 		virtual ~DiagMessageTask(void);
 
+		//! \brief Tick the DiagMessageTask.
 		virtual void update(float dt);
 
+		//! \brief Update the duration and timed status of the message.
 		void setTimed(float duration);
 
+		//! \brief Update the message and coordinates of the message
 		void setMessage(const char *message, int x, int y);
+
 	private:
+		//! \brief Remove 2D overlay, unload the renderer resources and free memory.
 		void removeOverlay();
 
 	protected:
@@ -40,5 +59,3 @@ namespace T3D{
 		Texture *diagOverlay = nullptr;
 	};
 }
-
-#endif

--- a/T3D/T3D/DrawTask.cpp
+++ b/T3D/T3D/DrawTask.cpp
@@ -9,41 +9,112 @@
 // Simple task for drawing to and animating textures, used in tutorial 1 for practice implementing drawing routines
 
 #include <math.h>
+#include "Renderer.h"
 #include "DrawTask.h"
 #include "Logger.h"
 
-namespace T3D {
-
-	// Creates a DrawTask that draws onto the Texture tex once per frame.
-	//
-	// Usage notes:
-	// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
-	//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
-	//
-	// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
-	//
-	// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
+namespace T3D 
+{
+	/*
+	 * \param app Application root
+	 * \param tex Texture to draw onto
+	 *
+	 * \note `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay. This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
+	 * \note If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
+	 * \note If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
+	 *
+	 */
 	DrawTask::DrawTask(T3DApplication *app, Texture* tex) : Task(app)
 	{
 		drawArea = tex;
 
-		// Reserve some space for the buffer, as it's extremely unlikely just one pixel will be plotted, and
-		// the common case is filled, non-sparse shapes
+		// Reserve some space for the buffer, as its unlikely only few pixels will be plotted
 		const uint32_t pixelsToReserve = 512;
 		pixelPlotQueue.reserve(pixelsToReserve);
 
 		init();
+		logger::Log(priority::Info, output_stream::All, category::Task, "Initialised DrawTask");
 	}
 
-	// Add a pixel to be displayed this frame to the PixelPlotQueue.
+	/*
+	 * \param 
+	 * \note This isn't necessary. It could be inlined into the constructor.
+	 */
+	void DrawTask::init	(){		
+		drawArea->clear(Colour(255,255,255,255));
+		drawDDALine(100,100,200,200,Colour(0,0,0,255));
+	}
+
+	/*
+	 * \param x1 Start x pixel coordinate 
+	 * \param y1 Start y pixel coordinate
+	 * \param x2 End x pixel coordinate 
+	 * \param y2 End y pixel coordinate
+	 * \param Colour of line
+	 *
+	 * \note Uses floating-point numbers as seen in the 2D graphics lecture.
+	 * \note `pushPixel` is used to do large batches of *bounds-checked* pixel drawing, which you may prefer to your application crashing if you go outside the texture area.
+	 */
+	void DrawTask::drawDDALine(int x1, int y1, int x2, int y2,Colour c){
+		float ystep = float(y2-y1) / (x2-x1);
+		float y = float(y1);
+
+		for (int x = x1; x < x2; x++){
+			pushPixel(x, int(y), c);
+			y += ystep;
+		}
+	}
+		
+
+	/*
+	 * \param x1 Start x pixel coordinate 
+	 * \param y1 Start y pixel coordinate
+	 * \param x2 End x pixel coordinate 
+	 * \param y2 End y pixel coordinate
+	 * \param Colour of line
+	 * 
+	 * \note UNIMPLEMENTED! That's your job in the tutorials.
+	 */
+	void DrawTask::drawBresLine(int x1, int y1, int x2, int y2,Colour c)
+	{ /* UNIMPLEMENTED */ }
+
+
+	/*
+	 * \param dt Change in time
+	 *
+	 * \note Make sure to clear the `drawArea` before you write to it.
+	 */
+	void DrawTask::update(float dt){
+		drawArea->clear(Colour(255, 255, 255, 255));
+		drawDDALine(100, 1000, 200, 200, Colour(255,0,0,255));
+
+		// Plots pixels made to the drawArea this frame, clearing the pixel queue.
+		flushPixelQueue();
+		app->getRenderer()->reloadTexture(drawArea);
+	}
+
+
+	/*
+	 * Provides a bounds-checked and more efficient way to draw onto a surface then `plotPixel()`.
+	 * Diagnostic messages for out-of-bounds drawing are displayed onto the console, and into `T3D_Log.txt`.
+	 * 
+	 * \param x x pixel coordinate to draw onto
+	 * \param y y pixel coordinate to draw onto
+	 * \param Colour pixel colour
+	 *
+	 */
 	void DrawTask::pushPixel(int x, int y, Colour colour)
 	{
 		pixelPlotQueue.push_back(Pixel { x, y, colour }); 
 	}
 
-	// Plots every pixel pushed to the DrawTask's pixel queue this frame before clearing the queue.
-	// If a pixel's X or Y coordinate is outside the drawable surface bounds, an error message is reported to stdout.
-	// Otherwise, the pixel is written to the surface.
+	/*
+	 * Provides a bounds-checked and more efficient way to draw onto a surface then `plotPixel()`.
+	 * Diagnostic messages for out-of-bounds drawing are displayed onto the console, and into `T3D_Log.txt`.
+	 *
+	 *
+	 * \note This should be called at the end of the `update` function.
+	 */
 	void DrawTask::flushPixelQueue()
 	{
 		const uint32_t MaxOutOfBoundsCount = 10u;
@@ -63,16 +134,16 @@ namespace T3D {
 				if (OutOfBoundsCount < MaxOutOfBoundsCount)
 				{
 					logger::Log(priority::Tracing,
-							    output_stream::All,
+							    output_stream::File,
 							    category::Debug,
 							   "Pixel out of bounds!\n"
 							   "\tWidth  :: [0 <= X <= %4u :: %4d :: %5s]%s\n"
 							   "\tHeight :: [0 <= Y <= %4u :: %4d :: %5s]%s\n"
 							   ,
-							   T3D::WindowWidth,
+							   app->getRenderer()->WindowWidth,
 							   Pixel.x, PixelWithinWidth  ? "OK" : "ERROR",
 							   PixelWithinWidth  ?   ""  : " <<<\n",
-							   T3D::WindowHeight,
+							   app->getRenderer()->WindowHeight,
 							   Pixel.y, PixelWithinHeight ? "OK" : "ERROR",
 							   PixelWithinHeight  ?  ""  : " <<<\n");
 				}
@@ -83,7 +154,7 @@ namespace T3D {
 		if (OutOfBoundsCount >= MaxOutOfBoundsCount)
 		{
 			logger::Log(priority::Tracing,
-						output_stream::All,
+						output_stream::File,
 						category::Debug,
 					   "... Repeats %u times ...\n"
 					   ,
@@ -93,41 +164,6 @@ namespace T3D {
 		pixelPlotQueue.clear();
 	}
 
-
-	// Ensures all pre-conditions are met for following calls to the `update` function.
-	void DrawTask::init	(){		
-		drawArea->clear(Colour(255,255,255,255));
-		drawDDALine(100,100,200,200,Colour(0,0,0,255));
-	}
-
-
-	// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
-	// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
-	void DrawTask::drawDDALine(int x1, int y1, int x2, int y2,Colour c){
-		float ystep = float(y2-y1)/(x2-x1);
-		float y = float(y1);
-		for (int x = x1; x<x2; x++){
-			pushPixel(x, int(y), c);
-			y += ystep;
-		}
-	}
-		
-
-	// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
-	// Bresenham algorithm from the 2D drawing lectures.
-	void DrawTask::drawBresLine(int x1, int y1, int x2, int y2,Colour c)
-	{ /* UNIMPLEMENTED */ }
-
-
-	// Provides one frames' worth of pixels to draw onto the screen.
-	void DrawTask::update(float dt){
-		drawArea->clear(Colour(255, 255, 255, 255));
-		drawDDALine(100, 10000, 200, 200, Colour(255,0,0,255));
-
-		// Plots pixels made to the drawing area this frame and clears the pixel queue.
-		flushPixelQueue();
-		app->getRenderer()->reloadTexture(drawArea);
-	}
 
 
 }

--- a/T3D/T3D/DrawTask.h
+++ b/T3D/T3D/DrawTask.h
@@ -9,58 +9,56 @@
 // Simple task for drawing to and animating textures, used in tutorial 1 for practice implementing drawing routines
 
 #pragma once
-#include "task.h"
+#include <vector>
+
+#include "Task.h"
 #include "T3DApplication.h"
+#include "Renderer.h"
 #include "Texture.h"
 
-namespace T3D{
-
+namespace T3D 
+{
+	//! \brief Task subclass, used for implementing 2D drawing routines. 
 	class DrawTask :
 		public Task
 	{
 	public:
-		// Creates a DrawTask that draws onto the Texture tex once per frame.
-		//
-		// Usage notes:
-		// - `tex` should be initialised, and registered with the renderer as both a loaded Texture and a 2D Overlay.
-		//   This can be done using `new Texture(...)`, `loadTexture(...)`, and finally `add2DOverlay(...)`.
-		//
-		// - If nothing is drawing on the screen, ensure the returned DrawTask object is added to the list of Tasks from the callsite using `addTask(...).
-		//
-		// - If there is nothing on the screen still, check the visual studio console for error messages in case something is out of bounds.
+		//! \brief Creates a DrawTask that draws onto a Texture every frame.
 		DrawTask(T3DApplication *app, Texture* tex);
+
+		//! \brief Destroy DrawTask (trivially). 
 		~DrawTask(void) = default;
 
-
-		// Ensures all pre-conditions are met for following calls to the `update` function.
-		// NOTE(Evan): This should really be inlined into the constructor or at least made private.
+		//! \brief Ensures that the drawing area is ready to be drawn onto.
 		void init();
 
-		// Draw a coloured line from (x1, y1) to (x2, y2) using the floating-point 
-		// Digital Differential Algorithm (DDA) algorithm from the 2D drawing lectures.
+		//! \brief Draw a coloured line between two points using the Digital Differential Algorithm (DDA) algorithm.
 		void drawDDALine(int x1, int y1, int x2, int y2, Colour c);
 
-		// Draw a coloured line from (x1, y1) to (x2, y2) using the integer-only
-		// Bresenham algorithm from the 2D drawing lectures.
-		// FIXME:
-		// - Not implemented yet! That's your job.
+		//! \brief Draw a coloured line from between two points using the integer-only Bresenham algorithm
 		void drawBresLine(int x1, int y1, int x2, int y2, Colour c);
 
-		// Provides one frames' worth of pixels to draw onto the screen.
+		//! \brief Ticks the drawing routine for this frame.
 		virtual void update(float dt);
 
 	private:
 		Texture *drawArea;
 
+		//! \brief Add a pixel to be displayed this frame to the PixelPlotQueue.
 		void pushPixel(int x, int y, Colour colour);
+
+		//! \brief Write all pushed pixel changes to drawArea, displaying errors to the console and log file.
 		void flushPixelQueue();
 
+		//! \brief Wrapper for pixel data, used by the pixel plot queue
 		struct Pixel
 		{
 			int x = 0;
 			int y = 0;
-			Colour colour = { 0xFF, 0, 0xFF, 0xFF }; // Anything dodgy should show up as purple.
+			Colour colour = { 0xFF, 0, 0xFF, 0xFF }; // Anything dodgy should show up as magenta
 		};
+
+		//! \brief One frames worth of pixels to blit onto the drawArea
 		std::vector<Pixel> pixelPlotQueue;
 	};
 

--- a/T3D/T3D/Font.cpp
+++ b/T3D/T3D/Font.cpp
@@ -8,19 +8,26 @@
 //
 // TTF_Font wrapper for font cache
 
-#include <iostream>
 #include "Font.h"
+#include "Logger.h"
 
 namespace T3D{
 
+	/*
+	 * \param filename Where the file is, as a relative path.
+	 * \param pointSize Font size. Differs per family, but 16 or so should be good.
+	 */
 	font::font(const char *filename, int pointSize)
 	{
 		name = filename;
 		size = pointSize;
 
 		ttf = TTF_OpenFont(filename, pointSize);
-		if (ttf == NULL) {
-			std::cout << "TTF_OpenFont() Failed: " << TTF_GetError() << std::endl;
+		if (!ttf) {
+			logger::Log(priority::Warning, 
+						output_stream::All,
+						category::Platform,
+						"TTF_OpenFont() Failed :: %s", TTF_GetError());
 		}
 
 	}

--- a/T3D/T3D/Font.h
+++ b/T3D/T3D/Font.h
@@ -7,15 +7,14 @@
 // Font.h
 //
 // This is a very simple wrapper around TTF_Font for use by the cache
+#pragma once
 
-#ifndef FONT_H
-#define FONT_H
-
-#include <vector>
+#include <string>
 #include <sdl\SDL_ttf.h>
 
-namespace T3D{
+namespace T3D {
 
+	//! \brief Font class wrapping SDL's TTF_Font.
 	class font
 	{
 	private:
@@ -24,9 +23,13 @@ namespace T3D{
 		int size;
 
 	public:
+		//! \brief Create font given a name and size
 		font(const char *filename, int pointSize);
+
+		//! \brief Destroy font
 		~font(void);
 
+		//! \brief Comparison helper used by `FontCache` -- checks if a font matches a family and size
 		bool matches_family_and_size(const char *filename, int pointSize);
 
 		TTF_Font *getFont() { return ttf; }
@@ -34,5 +37,3 @@ namespace T3D{
 	};
 
 }
-
-#endif //FONT

--- a/T3D/T3D/FontCache.cpp
+++ b/T3D/T3D/FontCache.cpp
@@ -1,5 +1,5 @@
 // =========================================================================================
-// 
+// KXG363 - Advanced Games Programming
 // =========================================================================================
 //
 // Author: David Pentecost
@@ -8,13 +8,17 @@
 //
 // SDL ttf font manager to allow reuse of loaded fonts
 
-#include <iostream>
 #include "FontCache.h"
+#include "Logger.h"
 
 namespace T3D{
 
-	// Get font from cache or load as required.
-	// returns NULL if font not available
+	/*
+	 * \param filename Where the file is, as a relative path.
+	 * \param pointSize Font size. Differs per family, but 16 or so should be good.
+	 *
+	 * \note Returns `nullptr` if the font doesn't exist, and a diagnostic message is output to the console and log file.
+	 */
 	font *FontCache::getFont(const char *filename, int pointSize)
 	{
 		// check the cache in case font is loaded
@@ -31,7 +35,10 @@ namespace T3D{
 		} 
 		else
 		{
-			// TODO(Evan): Log!
+			logger::Log(priority::Warning, 
+						output_stream::All,
+						category::Platform,
+						"Font creation failed!");
 		}
 
 		return maybe_font;

--- a/T3D/T3D/FontCache.h
+++ b/T3D/T3D/FontCache.h
@@ -7,15 +7,14 @@
 // FontCache.h
 //
 // SDL ttf font manager to allow reuse of loaded fonts
-
-#ifndef FONTCACHE_H
-#define FONTCACHE_H
+#pragma once
 
 #include <vector>
 #include "Font.h"
 
-namespace T3D{
+namespace T3D {
 
+	//! \brief Manages a reusable collection of font families in different sizes.
 	class FontCache
 	{
 	private:
@@ -25,9 +24,8 @@ namespace T3D{
 		FontCache(void)  = default;
 		~FontCache(void) = default;
 
+		//! \brief Grab a font, hitting the cache first if its in memory.
 		font *getFont(const char *filename, int pointSize);
 	};
 
 }
-
-#endif //FONTCACHE

--- a/T3D/T3D/GLRenderer.h
+++ b/T3D/T3D/GLRenderer.h
@@ -7,15 +7,10 @@
 // glrenderer.h
 //
 // Handles rendering tasks using OpenGL
-
-#ifndef GLRENDERER_H
-#define GLRENDERER_H
-
-#define WINDOW_WIDTH		1024
-#define	WINDOW_HEIGHT		640
+#pragma once
 
 #include <list>
-#include "renderer.h"
+#include "Renderer.h"
 
 namespace T3D
 {
@@ -29,24 +24,39 @@ namespace T3D
 	} overlay2D;
 
 
+	//! \brief OpenGL renderer. Manages 2D overlays, skyboxes, materials and renders meshes.
 	class GLRenderer :
 		public Renderer
 	{
 	public:
+		//! \brief Create GLRenderer (trivially).
 		GLRenderer(void)          = default;
+
+		//! \brief Destroy GLRenderer (trivially).
 		virtual ~GLRenderer(void) = default;
 
+		//! \brief Setup OpenGL state, such as clearing depth, colour and stencil buffers.
 		void prerender();
+
+		//! \brief Post-render hooks such as 2D overlays using orthographic projection.
 		void postrender();
 
+		//! \brief Set Camera to render scene from perspective of.
 		void setCamera(Camera *cam);
 
+		//! \brief Draw an Object's Mesh with respect to Material and Transform.
 		void draw(GameObject* object);
 		
+		//! \brief Register the Texture with OpenGL, setting its ID.
 		void loadTexture(Texture *tex, bool repeat = false);
+
+		//! \brief Reload the Texture. Does not retain the same ID.
 		void reloadTexture(Texture *tex);
+
+		//! \brief Unload the Texture from OpenGL.
 		void unloadTexture(Texture *tex);
 
+		//! \brief Load 6 faces of a Skybox bitmap from path.
 		void loadSkybox(std::string tex);
 
 		bool exists2DOverlay(Texture *texture);					// is there a existing 2D overlay using this texture?
@@ -70,5 +80,3 @@ namespace T3D
 
 	};
 }
-
-#endif

--- a/T3D/T3D/GLShader.h
+++ b/T3D/T3D/GLShader.h
@@ -10,28 +10,36 @@
 
 #pragma once
 
-#include "shader.h"
+#include "Shader.h"
 
-namespace T3D{
+namespace T3D {
 
+	//! \brief OpenGL Shader subclass for creating and compiling shaders from source code.
 	class GLShader : public Shader
 	{
 	public:
-		GLShader(std::string vertFilename, std::string fragFilename) 
-			: Shader(vertFilename, fragFilename),
-		      vertID(0),
-		      fragID(0),
-		      id    (0) { }
+		//! \brief Create GL shader program using Vertex and Fragment source code.
+		//! \note Check `T3D_Log.txt` if your shader program is not working!
+		GLShader(std::string vertFilename, 
+				 std::string fragFilename)  : Shader(vertFilename, fragFilename),
+											  vertID(0),
+		      								  fragID(0),
+		      								  id    (0) { }
 
 		~GLShader(void) = default;
 		
 		virtual void compileShader();
 		virtual void bindShader();
 		virtual void unbindShader();
+
 	protected:
-		unsigned int vertID;
-		unsigned int fragID;
-		unsigned int id;
+		uint32_t vertID;
+		uint32_t fragID;
+		uint32_t id;
+
+	private:
+		void checkShaderErrors(uint32_t shaderID);
+		void checkProgramErrors(uint32_t programID);
 	};
 
 }

--- a/T3D/T3D/GLTestApplication.cpp
+++ b/T3D/T3D/GLTestApplication.cpp
@@ -10,6 +10,7 @@
 
 #include "GLTestApplication.h"
 #include "GLTestRenderer.h"
+#include "Transform.h"
 
 namespace T3D{
 

--- a/T3D/T3D/GLTestApplication.h
+++ b/T3D/T3D/GLTestApplication.h
@@ -9,10 +9,10 @@
 // A dummy application for running the GLTestRenderer (used as an OpenGL sandbox)
 
 #pragma once
-#include "winglapplication.h"
+#include "WinGLApplication.h"
 
 
-namespace T3D{
+namespace T3D {
 
 	class GLTestApplication :
 		public WinGLApplication

--- a/T3D/T3D/GLTestRenderer.h
+++ b/T3D/T3D/GLTestRenderer.h
@@ -9,7 +9,7 @@
 // A dummy renderer that ignores the scene entirely.  Intended to be used as an OpenGL snadbox.
 
 #pragma once
-#include "glrenderer.h"
+#include "GLRenderer.h"
 
 namespace T3D{
 

--- a/T3D/T3D/GameObject.cpp
+++ b/T3D/T3D/GameObject.cpp
@@ -14,7 +14,7 @@
 #include "Transform.h"
 #include "Camera.h"
 #include "Light.h"
-#include "Terrain.h"
+#include "Renderer.h"
 
 namespace T3D
 {
@@ -25,12 +25,12 @@ namespace T3D
 	{
 		this->app = app;
 		setTransform(new Transform());
-		camera = NULL;
-		mesh = NULL;
+		camera   = NULL;
+		mesh     = NULL;
 		material = NULL;
-		light = NULL;
-		visible = true;
-		alpha = 1.0f;
+		light    = NULL;
+		visible  = true;
+		alpha    = 1.0f;
 	}
 
 	/*! Destructor
@@ -41,17 +41,16 @@ namespace T3D
 	GameObject::~GameObject(void)
 	{
 		if (camera) delete camera;
-		if (mesh) delete mesh;
-		if (light) delete light; // TODO: should make sure that this is removed from renderer's list of lights
+		if (mesh)   delete mesh;
+		if (light)  delete light; // TODO: should make sure that this is removed from renderer's list of lights
 
-		std::vector<Component*>::iterator ci;
-		for (ci = components.begin(); ci != components.end(); ci++) {
-			delete (*ci);
+		for (auto &component: components) {
+			delete component;
 		}
 
 		// don't delete transform - normally gameobject delete will be called from transform delete
 	}
-
+			
 	/*! Sets the Transform for this component
 	  Set's the new Transform and updates the corrsponding link for the new Transform
 	  \param t		The new Transform
@@ -154,11 +153,9 @@ namespace T3D
 	  \param dt		The time that has passed since the last update (in seconds)
 	  */
 	void GameObject::update(float dt){
-		std::vector<Component*>::iterator it;
-
-		for ( it=components.begin() ; it < components.end(); it++ )
+		for (auto component: components)
 		{
-			(*it)->update(dt);
+			component->update(dt);
 		}
 	}
 }

--- a/T3D/T3D/GameObject.h
+++ b/T3D/T3D/GameObject.h
@@ -7,9 +7,7 @@
 // GameObject.h
 //
 // Class to manage all information relating to objects in the scene.  Includes link to Transform and all Components
-
-#ifndef GAMEOBJECT_H
-#define GAMEOBJECT_H
+#pragma once
 
 #include <vector>
 #include "Mesh.h"
@@ -24,62 +22,114 @@ namespace T3D
 	class Light;
 
 	//! Generic class for all objects that exist in the world
-	/*! A GameObject's location is defined by the attached Transform.  The behaviour of a GameObject is customised by adding one or more Component's.  
-	    Special Component's such as Light's, Camera's and Material's, should be added using the appropriate method.
-	  \author  Robert Ollington
-	  */
-
+	/*! 
+	 * A GameObject's location is defined by the attached Transform.  
+	 * The behaviour of a GameObject is customised by adding one or more Component's.  
+	 * Special Component's such as Light's, Camera's and Material's, should be added using the appropriate method.
+	 * 
+	 * \note A common mistake is to not add the attached Transform component to the root of the scene graph. See T3DTest for an example.
+	 * \note The order which Components are updated is based on the order they are added / deleted - beware of issues with multiple Transform-modifying components!
+	 * \author  Robert Ollington
+	 */
 	class GameObject
 	{
 	public:
+		//! \brief Create a GameObject associated with a T3DApplication
 		GameObject(T3DApplication *app);
+
+		//! \brief Destroy a GameObject and its components
 		~GameObject(void);
 
+		//! \brief Attach Transform component
 		void setTransform(Transform *t);
+
+		//! \brief Get Transform component
 		Transform* getTransform();
 		
+		//! \brief Attach Camera component
+		//! \note Use `setCamera` on the Renderer to draw the scene from the perspective of the GameObject
 		void setCamera(Camera *s);
+
+		//! \brief Get Camera component
 		Camera* getCamera();
 		
+		//! \brief Attach Light component
 		void setLight(Light *l);
+
+		//! \brief Get Light component
 		Light* getLight();
 
+		//! \brief Attach Material component
 		void setMaterial(Material *m);
+
+		//! \brief Get Material component
 		Material* getMaterial();
 		
+		//! \brief Attach Mesh component
 		void setMesh(Mesh *m);
+
+		//! \brief Get Mesh component
 		Mesh* getMesh();
 
-		T3DApplication* getApp(){return app; }
+		//! \brief Return Application root; useful for obtaining Renderer handle.
+		T3DApplication *getApp() { return app; }
 
+		//! \brief Add a Component to the GameObject.
+		//! \note For Components such as `Mesh`, `Light`, `Material` etc, use the dedicated functions.
 		void addComponent(Component *component);
+
+		//! \brief Update the GameObject and all its components.
 		void update(float dt);
 
+		//! \brief Set distance to Camera. Used for sorted draw order.
 		void setDistanceToCamera(float distance) { distanceToCamera = distance; }
-		float getDistanceToCamera() const { return distanceToCamera; }
 
+		//! \brief Get distance to Camera. Used for sorted draw order.
+		float getDistanceToCamera() const        { return distanceToCamera; }
+
+		//! \brief Set rendering visibility. 
 		void setVisible(bool visible) { this->visible = visible; }
-		bool isVisible() { return visible; }
 
-		void setAlpha(float alpha) { this->alpha = alpha; }		// 
-		float getAlpha() { return alpha; }
+		//! \brief Query rendering visibility.
+		bool isVisible()              { return visible; }
+
+		//! \brief Set alpha override.
+		//! \note This will override the GameObject's Material if < 1.0
+		void setAlpha(float alpha) { this->alpha = alpha; }
+		float getAlpha()           { return alpha; }
 
 	protected:
+		//! \brief Application root. Provides handle to Renderer.
 		T3DApplication *app;
-		Transform* transform;
-		Camera* camera;
-		Light* light;
-		Material* material;
-		Mesh* mesh;
-		float alpha;			// override material alpha if < 1.0
+
+		//! \brief Transform position in the scene graph.
+		Transform  *transform;
+
+		//! \brief Camera object associated with a scene.
+		Camera *camera;
+
+		//! \brief Light associated with GameObject.
+		Light *light;
+
+		//! \brief Material associated with GameObject.
+		Material *material;
+
+		//! \brief Mesh associated with GameObject.
+		Mesh *mesh;
+
+		//! \brief Material alpha; override is < 1.0f
+		float alpha;
 
 	private:		
+		//! \brief Container of Components this GameObject has.
 		std::vector<Component*> components;
 
-		bool visible;						// object drawn or not
-		float distanceToCamera;				// this is a temp value for sorted draw order only
+		//! \brief Will GameObject be drawn or not
+		bool visible;
+
+		//! \brief Temporary valued used for sorted draw order only.
+		float distanceToCamera;
 
 	};
 }
 
-#endif

--- a/T3D/T3D/Input.h
+++ b/T3D/T3D/Input.h
@@ -8,9 +8,7 @@
 //
 // Simple static class to track keyboard and mouse
 // Adapted from Ogre3D
-
-#ifndef INPUT_H
-#define INPUT_H
+#pragma once
 
 namespace T3D
 {
@@ -143,6 +141,7 @@ namespace T3D
 
 	#define MAX_KEYS 512
 
+	//! \brief Stores keyboard and mouse input for the current frame.
 	class Input
 	{
 	public:
@@ -155,6 +154,3 @@ namespace T3D
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/KeyboardController.h
+++ b/T3D/T3D/KeyboardController.h
@@ -4,18 +4,16 @@
 //
 // Author: Robert Ollington
 //
-// keyboardcontroller.h
+// KeyboardController.h
 //
-// Component to add FPS-like controls to a game object
+// Component to add flying controls to a game object
+#pragma once
 
-#ifndef KEYBOARDCONTROLLER_H
-#define KEYBOARDCONTROLLER_H
-
-#include "component.h"
+#include "Component.h"
 
 namespace T3D
 {
-
+	//! \brief Add fly camera controls to a GameObject.
 	class KeyboardController :
 		public Component
 	{
@@ -34,6 +32,3 @@ namespace T3D
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/Light.cpp
+++ b/T3D/T3D/Light.cpp
@@ -6,11 +6,9 @@
 //
 // light.cpp
 //
-// Compnent to add lights to a game object
-
-#include "Light.h"
+// Component to add lights to a game object
 
 namespace T3D
 {
-	/* Plain old data class (with a non-owning GameObject pointer) : Initialiser inside header. */
+	/* Plain old data class : Initialiser inside header. */
 }

--- a/T3D/T3D/Light.h
+++ b/T3D/T3D/Light.h
@@ -6,21 +6,21 @@
 //
 // light.h
 //
-// Compnent to add lights to a game object
+// Component to add lights to a game object
+#pragma once
 
-#ifndef LIGHT_H
-#define LIGHT_H
-
-#include "component.h"
+#include "Component.h"
 
 namespace T3D
 {
+	// \brief Add light to GameObject.
 	class Light :
 		public Component
 	{
 	public:
 		enum class Type { AMBIENT, DIRECTIONAL, POINT, SPOT };
 
+		// \brief Create a Light, ambient by default with zeroed parameters.
 		Light(Type type = Type::AMBIENT) : Component(),        /* super */
 									       type                (type),
 									       enabled             (true),
@@ -31,15 +31,17 @@ namespace T3D
 										   ambient			   (/* zero */),
 										   diffuse 			   (/* zero */),
 										   specular			   (/* zero */) { }
+
+		// \brief Destroy a Light (trivially).
 		~Light(void) = default;
 
-		// Initialise (Blinn-)Phong lighting model terms
+		// Initialise Phong lighting model terms
 		void setAmbient(float r, float g, float b, float a = 1.0)  { ambient[0]  = r; ambient[1]  = g; ambient[2]  = b; ambient[3]  = a; }
 		void setDiffuse(float r, float g, float b, float a = 1.0)  { diffuse[0]  = r; diffuse[1]  = g; diffuse[2]  = b; diffuse[3]  = a; }
 		void setSpecular(float r, float g, float b, float a = 1.0) { specular[0] = r; specular[1] = g; specular[2] = b; specular[3] = a; }
 
 	public:
-		Type type;
+		Light::Type type;
 		bool enabled;
 
 		float ambient[4];
@@ -51,6 +53,3 @@ namespace T3D
 		float quadraticAttenuation;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/LookAtBehaviour.h
+++ b/T3D/T3D/LookAtBehaviour.h
@@ -7,16 +7,14 @@
 // LookAtBehaviour.cpp
 //
 // A component used for making a component face another transform.  Basically just a wrapper for the Transform lookAt method.
+#pragma once
 
-#ifndef LOOKATBEHAVIOUR_H
-#define LOOKATBEHAVIOUR_H
-
-#include "component.h"
-#include "Vector3.h"
+#include "Component.h"
 #include "Transform.h"
 
 namespace T3D
 {
+	//! \brief A component that makes one Transform 'look at' another.
 	class LookAtBehaviour :
 		public Component
 	{
@@ -29,6 +27,3 @@ namespace T3D
 		Transform *target;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Main.cpp
+++ b/T3D/T3D/Main.cpp
@@ -20,7 +20,7 @@
 
 using namespace T3D;
 
-int main(int argc, char* argv[]){
+int main(int argc, char* argv[]) {
 	T3DApplication *theApp = new T3DTest();
 	//T3DApplication *theApp = new Tutorial1();
 	//T3DApplication *theApp = new GLTestApplication();

--- a/T3D/T3D/Material.cpp
+++ b/T3D/T3D/Material.cpp
@@ -8,47 +8,34 @@
 //
 // Class for encapsulating material properties
 
-#include "material.h"
+#include "Material.h"
+#include <array>
 
-namespace T3D{
-	Material::Material(void)
-	{
-		setDiffuse(1,1,1,1);
-		setSpecular(1,1,1,1);
-		setEmissive(0,0,0,1);
-		shininess = 100;
+namespace T3D {
 
-		textured = false;
-		texture = NULL;
-		textureScale = 1.0;
+	/* NOTE(Evan): 
+	   `std::array<T, N>` is used to delegate the public overloaded constructors 
+	   as a quick-and-dirty fix to C++ not supporting C-style array literal compound initialisers.
+	   In English, both public constructors will be ambigious without using `std::array` 
+	   as they could be an initialiser list {r, b, g, a} for the `r, b, g, a` constructor OR a compound array literal intended for the private constructor. Yikes.
 
-		shader = NULL;
+	   On the plus side, migrating to a shared delegating constructor caught some nasty 
+	   uninitialized member bugs that MSVC couldn't detect with the prior (copy-pasted) constructors.
+    */
+	Material::Material(std::array<float, 4> d) : diffuse{d[0], d[1], d[2], d[3]},
+									             specular{1, 1, 1, 1},
+									             emissive{0, 0, 0, 1},
+									             shininess(100),
+									             textured(false),
+									             texture(nullptr),
+									             textureScale(1.0f),
+									             shader(nullptr),
+									             smooth(true),	
+									             sortedDraw(false),
+									             disableDepth(false),
+												 blending(BlendMode::DEFAULT) { }
+                        
+	Material::Material(void)							   : Material(std::array<float, 4>{ 1, 1, 1, 1 }) { }
+	Material::Material(float r, float g, float b, float a) : Material(std::array<float, 4>{ 0, 0, 0, 1 }) { }
 
-		smooth = true;
-
-		sortedDraw = false;
-		disableDepth = false;
-	}
-
-	Material::Material(float r, float g, float b, float a)
-	{
-		setDiffuse(r,g,b,a);
-		setSpecular(1,1,1,1);
-		setEmissive(0,0,0,1);
-		shininess = 100;
-
-		textured = false;
-		texture = NULL;
-		textureScale = 1.0;
-
-		smooth = true;
-
-		sortedDraw = false;
-		disableDepth = false;
-	}
-
-
-	Material::~Material(void)
-	{
-	}
 }

--- a/T3D/T3D/Material.h
+++ b/T3D/T3D/Material.h
@@ -7,11 +7,8 @@
 // material.h
 //
 // Stores material properties for an object
+#pragma once
 
-#ifndef MATERIAL_H
-#define MATERIAL_H
-
-#include <vector>
 #include <queue>
 #include "Texture.h"
 #include "Shader.h"
@@ -20,35 +17,49 @@ namespace T3D
 {
 	class GameObject;
 
+	//! \brief Material class for implementing lighting models using shaders, textures and colours.
+	/*
+	 * Typical use of the Material class is to give it a Texture, using `setTexture()`.
+	 * Then, you add the Material to a GameObject using `setMaterial()` on it.
+	 * Double check you've added a Mesh to the GameObject, and that the GameObject's Transform has the root of
+	 * the scenegraph as its root.
+	 */
 	class Material
 	{
 	public:
 		enum class BlendMode 
 		{
 			NONE,				// no texture blending
-			DEFAULT,			// alpha blending (sourcd alpha=0.0 invisible, alpha=1.0 opaque)
+			DEFAULT,			// alpha blending (source alpha=0.0 invisible, alpha=1.0 opaque)
 			ADD,				// source and destination colour added
 			MULTIPLY			// Source and Destination colour multiplied
 		};
 
+		//! \brief Create Material with default parameters - opaque white diffuse coloured.
 		Material(void);
-		Material(float r, float g, float b, float a);
-		virtual ~Material(void);
 
-		void setDiffuse(float r, float g, float b, float a){ diffuse[0] = r;  diffuse[1] = g; diffuse[2] = b; diffuse[3] = a; }
+		//! \brief Create Material with default parameters, and specific diffuse colours.
+		Material(float r, float g, float b, float a);
+
+		//! \brief Destroy Material (trivially)
+		~Material(void) = default;
+
+		void setDiffuse(float r, float g, float b, float a) { diffuse[0] = r;  diffuse[1] = g; diffuse[2] = b;    diffuse[3]  = a; }
 		void setSpecular(float r, float g, float b, float a){ specular[0] = r;  specular[1] = g; specular[2] = b; specular[3] = a; }
 		void setEmissive(float r, float g, float b, float a){ emissive[0] = r;  emissive[1] = g; emissive[2] = b; emissive[3] = a; }
-		void setShininess(float s){ shininess = s; }
-		void setFlatShading() { smooth = false; }
-		void setSmoothShading() { smooth = true; }
+
+		void setShininess(float s)       { shininess = s; }
+		void setFlatShading()            { smooth = false; }
+		void setSmoothShading()          { smooth = true; }
 		void setBlending(BlendMode mode) { blending = mode; }
 
-		bool isTextured(){ return textured; }
+		bool isTextured()      { return textured; }
 		unsigned int getTexID(){ return texture->getID(); }
 		void setTexture(Texture *tex, float scale = 1.0){ texture = tex; textured = true; textureScale = scale; }
-		Texture* getTexture(){ return texture; }
-		void setTextureScale(float s){ textureScale = s; }
-		float getTextureScale(){ return textureScale; }
+		Texture* getTexture()                           { return texture; }
+
+		void setTextureScale(float s) { textureScale = s; }
+		float getTextureScale()       { return textureScale; }
 
 		void setShader(Shader* s){ shader = s; }
 		Shader* getShader(){ return shader; }
@@ -56,19 +67,20 @@ namespace T3D
 		void addToQueue(GameObject* gameObject){ renderQueue.push(gameObject); }
 		std::queue<GameObject*> &getQueue(){ return renderQueue; }
 
-		float* getDiffuse(){ return diffuse; }
-		float* getSpecular(){ return specular; }
-		float* getEmissive(){ return emissive; }
-		float getShininess(){ return shininess; }
+		float* getDiffuse()  { return diffuse;   }
+		float* getSpecular() { return specular;  }
+		float* getEmissive() { return emissive;  }
+		float getShininess() { return shininess; }
 
 		bool getSmoothShading() { return smooth; }
 		BlendMode getBlending() { return blending; }
 
 		void setSortedDraw(bool sort, bool noDepthWrite) { sortedDraw = sort; disableDepth = noDepthWrite; }
-		bool getSortedDraw() { return sortedDraw; }
+		bool getSortedDraw()  { return sortedDraw; }
 		bool getDisablDepth() { return disableDepth; }
 
 	private:
+		Material(std::array<float, 4> d); /* internal delegating constructor */
 		float diffuse[4];
 		float specular[4];
 		float shininess;
@@ -89,6 +101,3 @@ namespace T3D
 		std::queue<GameObject*> renderQueue;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Math.cpp
+++ b/T3D/T3D/Math.cpp
@@ -14,12 +14,12 @@
 
 namespace T3D
 {
-    const float Math::PI = float( 4.0 * atan( 1.0 ) );
-    const float Math::TWO_PI = float( 2.0 * PI );
-    const float Math::HALF_PI = float( 0.5 * PI );
-	const float Math::DEG2RAD = PI / float(180.0);
+    const float Math::PI      = float( 4.0f * atan( 1.0f ) );
+    const float Math::TWO_PI  = float( 2.0f * PI );
+    const float Math::HALF_PI = float( 0.5f * PI );
+	const float Math::DEG2RAD = PI / float(180.0f);
 	const float Math::RAD2DEG = float(180.0f) / PI;
-	const float Math::LOG2 = float(log(2.0f));
+	const float Math::LOG2    = float(log(2.0f));
 
 	
 	float** Math::generateFractal(int size, float low, float high, float roughness, bool tile){

--- a/T3D/T3D/Math.h
+++ b/T3D/T3D/Math.h
@@ -8,19 +8,23 @@
 //
 // Currently just a few constants
 // Adapted from Ogre3D
-
-#ifndef MATH_H
-#define MATH_H
+#pragma once
 
 #include <cstdlib>
 #include <algorithm>
 
+// TODO: Fix windows.h using preprocessor symbol NOMINMAX. IIRC, SDL includes windows.h -- maybe do it before then?
+#ifdef min
 #undef min
+#endif
+
+#ifdef max
 #undef max
+#endif
 
 namespace T3D
 {
-
+	//! \brief Helpful constants and free functions.
 	class Math
 	{
 	public:
@@ -31,7 +35,14 @@ namespace T3D
 		static const float RAD2DEG;
 		static const float LOG2;
 
-		static float lerp(float first, float second, float t){ return t*(second-first)+first; }
+		//! \brief Linearly interpolate between two values, based on time t.
+		/*
+		 * \param first starting value
+		 * \param second ending value
+		 * \param t time (aka alpha)
+		 *
+		 */
+		static float lerp(float first, float second, float t) { return t*(second-first)+first; }
 
 		static float** generateFractal(int size, float min, float max, float roughness, bool tile = false);
 
@@ -40,7 +51,7 @@ namespace T3D
 		  \param minimum	range from 
 		  \param maximum	range to 
 		  */
-		static float randRange(float minimum, float maximum){ 
+		static float randRange(float minimum, float maximum) { 
 			float r = float(rand())/RAND_MAX;
 			return r*(maximum-minimum)+minimum; 
 		}
@@ -51,7 +62,7 @@ namespace T3D
 		  limit theorem.
 		  \param minimum	range from 
 		  \param maximum	range to 
-		  \param maximum	iterations (more for better distribution curve)
+		  \param iterations	iterations (more for better distribution curve)
 		  */
 		static float randRangeND(float minimum, float maximum, int iterations=3){ 
 			float r = 0;
@@ -60,6 +71,13 @@ namespace T3D
 			return r / (float)iterations * (maximum - minimum) + minimum; 
 		}
 
+		//! \brief Ensure value lies between an inclusive min and max
+		/*
+		 * \param value value to clamp
+		 * \param minimum lower bound (inclusive)
+		 * \param maximum upper bound (inclusive)
+		 *
+		 */
 		static float clamp(float value, float minimum, float maximum){ 
 			return std::max(
 				std::min(maximum,value),minimum
@@ -67,6 +85,3 @@ namespace T3D
 		}
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Matrix3x3.h
+++ b/T3D/T3D/Matrix3x3.h
@@ -8,17 +8,16 @@
 //
 // 3x3 matrix class
 // Adapted from Ogre3D
+#pragma once
 
-#ifndef MATRIX3X3_H
-#define MATRIX3X3_H
-
-#include <algorithm>
 #include <assert.h>
+#include <string>
 
 #include "Vector3.h"
 
 namespace T3D
 {
+	//! \brief 3x3 Matrix, suitable for 2D affine transformations using homogeneous coordinates or storing 3d rotation/scale.
     class Matrix3x3
     {
     protected:
@@ -153,5 +152,3 @@ namespace T3D
 	/** @} */
 	/** @} */
 }
-
-#endif

--- a/T3D/T3D/Matrix4x4.h
+++ b/T3D/T3D/Matrix4x4.h
@@ -8,11 +8,8 @@
 //
 // 4x4 matrix class
 // Adapted from Ogre3D
+#pragma once
 
-#ifndef MATRIX4X4_H
-#define MATRIX4X4_H
-
-#include <algorithm>
 #include <assert.h>
 #include "Vector3.h"
 #include "Vector4.h"
@@ -21,6 +18,7 @@
 
 namespace T3D
 {
+	//! \brief 4x4 Matrix, suitable for 3D affine transformations using homogeneous coordinates.
 	class Matrix4x4
 	{
     protected:
@@ -572,5 +570,3 @@ namespace T3D
 	/** @} */
 
 }
-
-#endif

--- a/T3D/T3D/Mesh.h
+++ b/T3D/T3D/Mesh.h
@@ -4,91 +4,160 @@
 //
 // Author: Robert Ollington
 //
-// mesh.h
+// Mesh.h
 //
-// Basic mesh class to store vertices, normals, colors, uvs(currently not used), and indices
-// Triangle meshes only.  Unoptimised.
-
-#ifndef MESH_H
-#define MESH_H
+// Basic mesh class to store vertices, normals, colors(currently not used), uvs, and indices
+// Unoptimised.
+#pragma once
 
 #include "Component.h"
 #include "Vector4.h"
 
 namespace T3D
 {
+	//! \brief Mesh component, stores vertices and their attributes such as normals, uvs, and indices.
+	/* A Mesh is intended to be used for procedurally generated shapes, by inheriting from the Mesh class
+	 * and implementing a constructor to do so. See `Cube.cpp` for an example.
+	 */
 	class Mesh : public Component
 	{
 	public:
-		// Create a Mesh with initialised buffers and zero counts.
+		//! \brief Create Mesh with initialised, empty buffers.
 		Mesh(void);
 
-		// Delete a Mesh's buffers with non-zero counts.
+		//! \brief Destroy Mesh, freeing buffers.
 		virtual ~Mesh(void);
 
 		// Accessors.
-		int           getNumVerts()    { return numVerts;    }
-		int           getNumTris()     { return numTris;     }
-		int           getNumQuads()    { return numQuads;    }
-		float*        getVertices()    { return vertices;    }
-		float*        getNormals()     { return normals;     }
-		float*        getColors()      { return colors;      }
-		float*        getUVs()         { return uvs;         }
-		unsigned int* getTriIndices()  { return triIndices;  }
-		unsigned int* getQuadIndices() { return quadIndices; }
+
+		//! \brief Get number of vertices.
+		int getNumVerts()    { return numVerts;    }
+
+		//! \brief Get number of triangles.
+		int getNumTris()     { return numTris;     }
+
+		//! \brief Get number of quads.
+		int getNumQuads()    { return numQuads;    }
+
+		//! \brief Get number of vertices.
+		float *getVertices()    { return vertices;    }
+
+		//! \brief Get number of normals.
+		float *getNormals()     { return normals;     }
+
+		//! \brief Get number of colors. \note Colors isn't really used!
+		float *getColors()      { return colors;      }
+
+		//! \brief Get number of UVs.
+		float *getUVs()         { return uvs;         }
+
+		//! \brief Get a pointer to the triangle index buffer.
+		uint32_t *getTriIndices()  { return triIndices;  }
+
+		//! \brief Get a pointer to the quad index buffer.
+		uint32_t *getQuadIndices() { return quadIndices; }
 
 
 
-		// Initialises internal buffers (Vertex, Index, UV, etc) based on
-		// the number of vertices the caller requires to render primitives.
+		//! \brief Initialises internal buffers (Vertex, Index, UV, etc) given vertex and index counts.
 		void initArrays(uint32_t numVerts, uint32_t numTris, uint32_t numQuads);
 
-		// Verbosely logs any vertices that are uninitialised.
-		// Call this at the end of _any_ procedural mesh generation!
+		//! \brief Issue warnings to console/log file if vertex, index, uv or colour buffers contain _obviously_ uninitialized/erroneous contents.
 		bool checkArrays();
 
-		// Calculates normals for Triangles and Quads. 
-		// - Quad normals may look a bit off.
+		//! \brief Calculates normals for Triangles and Quads. 
+		/* 
+		 * \note The Mesh may contain more then numVerts after this function returns if any of the quads are nonplanar (i.e. has a curvature).
+		 */
 		void calcNormals();
 		
-		// Negates all normals (i.e. flips them facing inwards to outwards, and vice versa)
+		//! \brief Negates all normals (i.e. flips them facing inwards to outwards, and vice versa)
 		void invertNormals();
 
+
 		// Procedural texture coordinate calculations for the primitives provided by T3D.
+
+		//! \brief Calculates UVs to wrap a spherical bounding mesh.
 		void calcUVSphere();
+
+		//! \brief Calculates UVs to wrap a XY-oriented plane.
 		void calcUVPlaneXY();
+
+		//! \brief Calculates UVs to wrap a YZ-oriented plane.
 		void calcUVPlaneYZ();
+
+		//! \brief Calculates UVs to wrap a XZ-oriented plane.
 		void calcUVPlaneXZ();
+
+		//! \brief Calculates UVs to wrap a cube. 
 		void calcUVCube();
 
-		virtual void    setVertex(int i, float x, float y, float z);
+		//! \brief Sets the ith vertex to have components x, y, z.
+		virtual void setVertex(int i, float x, float y, float z);
+
+		//! \brief Returns the ith vertex.
 		virtual Vector3 getVertex(int i);
-		virtual void    setColor(int i, float r, float g, float b, float a);
+
+		// \brief Sets the ith color to have components r, g, b, a
+		virtual void setColor(int i, float r, float g, float b, float a);
+
+		// \brief Returns the ith color.
 		virtual Vector4 getColor(int i);
-		virtual void    setNormal(int i, float x, float y, float z);
-		virtual void    setNormal(int i, Vector3 n);
-		virtual void    addNormal(int i, Vector3 n);
-		virtual void    normalise();
+
+		// \brief Sets the ith normal to have components x, y, z.
+		virtual void setNormal(int i, float x, float y, float z);
+
+		// \brief Sets the ith normal to the vector n.
+		virtual void setNormal(int i, Vector3 n);
+
+		// \brief Adds the vector n to the ith normal.
+		virtual void addNormal(int i, Vector3 n);
+
+		// \brief Calculates and set every vertex normal to be unit length, i.e. normalized.
+		virtual void normalise();
+
+		// \brief Returns the ith normal.
 		virtual Vector3 getNormal(int i);
-		virtual void    setTriFace(int i, int a, int b, int c);
-		virtual void    setQuadFace(int i, int a, int b, int c, int d);
-		virtual void    setUV(int i, float u, float v);
+
+		// \brief Sets the ith triFace to contain indices referring to vertices at positions a, b, c.
+		virtual void setTriFace(int i, int a, int b, int c);
+
+		// \brief Sets the ith quadFace to contain indices referring to vertices at positions a, b, c, d.
+		virtual void setQuadFace(int i, int a, int b, int c, int d);
+
+		//! \brief Sets the ith UV.
+		virtual void setUV(int i, float u, float v);
 
 
 	protected:
-		unsigned int numVerts, numTris, numQuads;
+		//! \brief Vertex count.
+		uint32_t numVerts; 
 
+		//! \brief Triangle count. Can be 0
+		uint32_t numTris;
+
+		//! \brief Quad count. Can be 0
+		uint32_t numQuads;
+
+		//! \brief Vertex buffer. Vertices are stored packed.
 		float *vertices;
+
+		//! \brief Normal buffer.
 		float *normals;
+
+		//! \brief Colour buffer. \note Currently unused.
 		float *colors;
+
+		//! \brief UV buffer.
 		float *uvs;
 
-		unsigned int *triIndices;
-		unsigned int *quadIndices;
+		//! \brief Triangle index buffer
+		uint32_t *triIndices;
 
-	private:
+		//! \brief Quad index buffer
+		uint32_t *quadIndices;
+
+		//! \brief Internal helper function for calculating UV planes.
 		void calcUVPlane(uint32_t vectorOffsetOne, uint32_t vectorOffsetTwo);
 	};
 }
-
-#endif

--- a/T3D/T3D/Music.cpp
+++ b/T3D/T3D/Music.cpp
@@ -9,6 +9,7 @@
 // Simple class used for streaming large sound files.  Uses FMod: www.fmod.org
 
 #include "Music.h"
+#include "Logger.h"
 
 namespace T3D{
 
@@ -20,6 +21,11 @@ namespace T3D{
 			channel->setVolume(volume);
 			channel->setPaused(false);
 		}
+
+		logger::Log(priority::Tracing,
+					output_stream::File,
+					category::Audio,
+					"Started playing music...");
 	}
 
 	void Music::setVolume(float v){		
@@ -34,6 +40,11 @@ namespace T3D{
 		if (channel) {
             channel->setPaused(true);
 		}
+
+		logger::Log(priority::Tracing,
+					output_stream::File,
+					category::Audio,
+					"Paused music...");
 	}
 	
 	void Music::stop(){		
@@ -41,6 +52,11 @@ namespace T3D{
 			channel->stop();
 			channel = NULL;
 		}
+
+		logger::Log(priority::Tracing,
+					output_stream::File,
+					category::Audio,
+					"Stopped music...");
 	}
 
 	bool Music::isPlaying(){

--- a/T3D/T3D/Music.h
+++ b/T3D/T3D/Music.h
@@ -16,6 +16,7 @@
 
 namespace T3D{
 
+	//! \brief Play, pause and adjust sounds loaded by a SoundManager.
 	class Music
 	{
 	friend class SoundManager;

--- a/T3D/T3D/ParticleBehaviour.cpp
+++ b/T3D/T3D/ParticleBehaviour.cpp
@@ -1,22 +1,19 @@
 //
 // Author: David Pentecost
 //
-// ParticleEmitter.h
+// ParticleEmitter.cpp
 //
 // Base particle behaviour.
-// This is a pure virtual class from which a useable particle must be derived.
 
 #include "GameObject.h"
-#include "Math.h"
 #include "ParticleEmitter.h"
 #include "ParticleBehaviour.h"
 
-
 namespace T3D
 {
-	/*! stop
-	  stop and hide particle
-	  */
+	/*! 
+	 * Stops a particle. Sets the GameObject to invisible and notifies parent of inactivity.
+	 */
 	void ParticleBehaviour::stop()
 	{
 		gameObject->setVisible(false);

--- a/T3D/T3D/ParticleBehaviour.h
+++ b/T3D/T3D/ParticleBehaviour.h
@@ -9,35 +9,34 @@
 #pragma once
 
 #include "Component.h"
-#include "Transform.h"
 
 namespace T3D
 {
+	class Transform;
 	class ParticleEmitter;
 
-	//  Standard Particle Behaviour
-	// Manages an individual particle for its lifetime
-	//    Particles are reusable
+	//! \brief Component to add Particle behaviour to a GameObject. Created from a parent ParticleEmitter. 
+	/* ParticleBehaviour manages an individual particle for its lifetime.
+	 * Particles are also reusable.
+	 */
+
 	class ParticleBehaviour  :
 		public Component
 	{
 	public:
-		/*! Constructor
-		  Initialises members
-		  */
+		// \brief Create ParticleBehaviour, initialising members
 		ParticleBehaviour::ParticleBehaviour(ParticleEmitter *emitter) : emitter(emitter),
-																	     active(0) { }
+																	     active(false) { }
+		virtual void start(Transform *from) = 0;		// start or restart particle
+		virtual void update(float dt) = 0;				// tick particle system
+		virtual void stop();							// stop and hide particle
+
 		bool isActive() { return active; }
-
-		virtual void start(Transform *from) = 0;			// start or restart particle
-		virtual void update(float dt) = 0;
-
-		virtual void stop();								// stop and hide particle
 
 	protected:
 		ParticleEmitter *emitter;		// parent emitter
 
-		bool active;			// particle is alive and active				
+		bool active;			// particle is alive and active
 	};
 
 }

--- a/T3D/T3D/ParticleEmitter.h
+++ b/T3D/T3D/ParticleEmitter.h
@@ -7,46 +7,63 @@
 // ParticleEmitter.h
 //
 // Particle emitter and controller
+#pragma once
 
-#ifndef PARTICLEEMITTER_H
-#define PARTICLEEMITTER_H
-
-#include <list>
+#include <vector>
 #include <queue>
+
 #include "Component.h"
 #include "ParticleBehaviour.h"
-
 
 namespace T3D
 {
 	class ParticleBehaviour;
 
-	//! Standard Particle Emitter
-	/*! The particle emitter generates and lauches reusable particles s
-	  \author  David Pentecost
-	  */
+	//! \brief Generate reusable particles.
 	class ParticleEmitter :
 		public Component
 	{
-	friend class ParticleBehaviour;
 	public:
-		ParticleEmitter(float duration, float startRate, float emitRate, float endRate,
-			float startUpTime, float windDownTime);
+		// \brief Create Particle emitter
+		ParticleEmitter(float duration, 
+						float startRate, 
+						float emitRate, 
+						float endRate,
+						float startUpTime, 
+						float windDownTime) :
+			duration(duration),
+			startRate(startRate),
+			emitRate(emitRate),
+			endRate(endRate),
+			rampUpDuration(startUpTime),
+			rampDownDuration(windDownTime),
+			emitted(0),
+			elapsed(0) { }
+
+		// \brief Deletes all particles
 		virtual ~ParticleEmitter();
 
-		void addParticle(ParticleBehaviour *particle, bool start);	// add particle to pool
-		void emit(int n);
-		void stop(bool clear);
-		void restart() { emitted = 0;  elapsed = 0; }				// restart from time 0
+		// \brief Adds a particle to the available pool.
+		void addParticle(ParticleBehaviour *particle, bool start);
 
+		// \brief Emit `n` particles immediatel	y
+		void emit(uint32_t n);											
+
+		// \brief Stop particle system
+		void stop(bool clear);
+
+		// \brief Restart timer
+		void restart() { emitted = 0;  elapsed = 0; }				
+
+		// \brief Tick particle system
 		void update(float dt);
 
-	private:
-		void addInactiveList(ParticleBehaviour *particle);	// only particles should call this!
-
 	protected:
-		std::vector<ParticleBehaviour *> particles;			// all particles
-		std::queue<ParticleBehaviour *> particlesInactive;	// inactive particles that can be reused
+		// \brief Set of all particles.
+		std::vector<ParticleBehaviour *> particles;
+
+		// \brief Inactive particles that can be reused.
+		std::queue<ParticleBehaviour *> particlesInactive;
 
 		float elapsed;					// elapsed time
 
@@ -62,10 +79,14 @@ namespace T3D
 		float rampDownDuration;			// wind down time from emitRate to endRate
 	
 	private:
+		// \brief Adds particle to inactive list for reuse
+		void addInactiveList(ParticleBehaviour *particle);	// only particles should call this!
+		// \brief Calculate expected particles at a timestep
 		float emitRamp(float start, float end, float duration, float time, float variability);
+
+	//! Need to maanage the members of ParticleBehaviour component instances.
+	friend class ParticleBehaviour;
 
 	};
 
 }
-
-#endif //PARTICLEEMITTER_H

--- a/T3D/T3D/ParticleGravity.cpp
+++ b/T3D/T3D/ParticleGravity.cpp
@@ -4,35 +4,16 @@
 //
 // A simple particle that applies gravity to a velocity for the particles lifespace
 
-
 #include "GameObject.h"
-#include "Math.h"
 #include "Transform.h"
 #include "ParticleGravity.h"
 
 namespace T3D
 {
-	// Constructor
-	ParticleGravity::ParticleGravity(ParticleEmitter *emitter, Vector3 initVelocity, float gravity, float lifeSpan) : ParticleBehaviour(emitter)
-	{
-		this->elapsed = 0;
-
-		this->initVelocity = initVelocity;
-		this->velocity = initVelocity;
-		this->gravity = gravity;
-		this->lifeSpan = lifeSpan;
-
-		this->alphaStart = 1.0f;
-		this->alphaEnd = 1.0f;
-	}
-
-
-	/*! start
-	Starts particle activity sequence
-	\param from		object to derive world position from
-
+	/*!
+	 * \param from	GameObject to derive world position from
 	*/
-	void ParticleGravity::start(Transform *from)			// start or restart particle
+	void ParticleGravity::start(Transform *from)
 	{
 		elapsed = 0;
 
@@ -47,18 +28,15 @@ namespace T3D
 	}
 
 
-	// setAlphaFade
-	// Sets alpha blending (fade) gradient from start to end
-	// of particle lifespan.
+	/* 
+	 * \todo ParticleGravity's constructor could take these as default parameters, along with Gravity.
+	 */
 	void ParticleGravity::setAlphaFade(float start, float end)
 	{
 		alphaStart = start;
 		alphaEnd = end;
 	}
 
-	// update
-	// regular update
-	//   param dt		elapsed (delta) time from last frame
 	void ParticleGravity::update(float dt)
 	{
 		if (active)		// particle is alive and running in particle system?

--- a/T3D/T3D/ParticleGravity.h
+++ b/T3D/T3D/ParticleGravity.h
@@ -1,11 +1,11 @@
-#pragma once
-
 // Author: David Pentecost
 //
 // ParticleGravity.h
 //
 // A simple particle that applies gravity to a velocity for the particles lifespace
+#pragma once
 
+#include "Vector3.h"
 #include "ParticleBehaviour.h"
 
 namespace T3D
@@ -14,11 +14,37 @@ namespace T3D
 		public ParticleBehaviour
 	{
 	public:
-		ParticleGravity(ParticleEmitter *emitter, Vector3 initVelocity, float gravity, float lifeSpan);
+		// \brief Initialise Particle.
+		/*
+		 * \param emitter		Parent emitter
+		 * \param initvelocity	Start velocity
+		 * \param gravity		Gravity acceleration, in meters per second^2.
+		 * \param lifespan		How long particle lives, in seconds
+		 *
+		 * \note Particles start fully opaque (i.e. alpha(Start|End) == 1.0f)
+		 */
+		ParticleGravity(ParticleEmitter *emitter, Vector3 initVelocity, float gravity, float lifeSpan) :
+			ParticleBehaviour(emitter),
+			elapsed          (0),
+			initVelocity     (initVelocity),
+			velocity         (initVelocity),
+			gravity          (gravity),
+			lifeSpan         (lifeSpan),
+			alphaStart       (1.0f),
+			alphaEnd         (1.0f) { }
 
+
+		// \brief Set alpha blending range. 
+		/*
+		 * \param start Start, in seconds
+		 * \param end End, in seconds
+		 */
 		void setAlphaFade(float start, float end);	// alpha fading from start to end of lifespan
 
+		// \brief Start particle activity sequence.
 		virtual void start(Transform *from);
+
+		// \brief Tick particle.
 		virtual void update(float dt);
 
 	protected:

--- a/T3D/T3D/PerfLogTask.cpp
+++ b/T3D/T3D/PerfLogTask.cpp
@@ -11,7 +11,12 @@
 #include <sstream>
 #include <fstream>
 #include <iomanip>
-#include "perflogtask.h"
+
+#include "PerfLogtask.h"
+#include "Font.h"
+#include "Renderer.h"
+#include "Colour.h"
+#include "Texture.h"
 
 namespace T3D{
 
@@ -48,7 +53,7 @@ namespace T3D{
 
 	void PerfLogTask::log(){		
 		std::ofstream logfile;
-		logfile.open ("perflog.txt", fstream::in | fstream::out | fstream::app);
+		logfile.open ("perflog.txt", std::fstream::in | std::fstream::out | std::fstream::app);
 		logfile.precision(1);
 		logfile << std::fixed;
 		logfile << "frames: " << frameCount << "\n";

--- a/T3D/T3D/PerfLogTask.h
+++ b/T3D/T3D/PerfLogTask.h
@@ -7,15 +7,16 @@
 // perflogtask.h
 //
 // Simple class to track framerates and write to file when app closes
+#pragma once
 
-#ifndef PERFLOGTASK_H
-#define PERFLOGTASK_H
+#include "Task.h"
 
-#include "task.h"
-
-namespace T3D{
-
+namespace T3D 
+{
 	#define PERF_SAMPLING_PERIOD	0.15			// calculation/update time period
+
+	class T3DApplication;
+	class Texture;
 
 	class PerfLogTask :
 		public Task
@@ -52,6 +53,3 @@ namespace T3D{
 		virtual void reset();		// reset elasped time, frame count, min/max frames times
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Plane.h
+++ b/T3D/T3D/Plane.h
@@ -8,14 +8,14 @@
 //
 // Represents a 3D plane
 // Adapted from Ogre3D
-
-#ifndef PLANE_H
-#define PLANE_H
+#pragma once
 
 #include <vector>
 #include "Vector3.h"
 
-namespace T3D {
+namespace T3D 
+{
+	// 3D plane with useful operator overloads for working with matrices and vectors.
     class Plane
     {
     public:
@@ -89,5 +89,3 @@ namespace T3D {
         friend std::ostream& operator<< (std::ostream& o, const Plane& p);
     };
 }
-
-#endif

--- a/T3D/T3D/PlaneMesh.cpp
+++ b/T3D/T3D/PlaneMesh.cpp
@@ -1,7 +1,18 @@
-#include "planemesh.h"
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// PlaneMesh.cpp
+//
+// Create a Mesh from a Plane representation
+// Adapted from Ogre3D
 
-namespace T3D{
+#include "PlaneMesh.h"
 
+namespace T3D
+{
 	PlaneMesh::PlaneMesh(int density) : density(density)
 	{
 		int numVerts = (density+1)*(density+1);
@@ -36,11 +47,6 @@ namespace T3D{
 		
 		// UVS
 		calcUVPlaneXZ();
-	}
-
-
-	PlaneMesh::~PlaneMesh(void)
-	{
 	}
 
 		

--- a/T3D/T3D/PlaneMesh.h
+++ b/T3D/T3D/PlaneMesh.h
@@ -1,15 +1,25 @@
-#ifndef PLANEMESH_H
-#define PLANEMESH_H
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// PlaneMesh.h
+//
+// Create a Mesh from a Plane representation
+// Adapted from Ogre3D
+#pragma once
 
-#include "mesh.h"
+#include "Mesh.h"
 
-namespace T3D{
+namespace T3D
+{
 	class PlaneMesh :
 		public Mesh
 	{
 	public:
 		PlaneMesh(int density);
-		~PlaneMesh(void);
+		~PlaneMesh(void) = default;
 
 		void setVertex(int i, int j, float x, float y, float z);
 		Vector3 getVertex(int i, int j);
@@ -17,6 +27,3 @@ namespace T3D{
 		int density;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/Quaternion.cpp
+++ b/T3D/T3D/Quaternion.cpp
@@ -7,5 +7,3 @@
 // Quaternion.cpp
 //
 // Quaternion class - all implementation is in the header
-
-#include "Quaternion.h"

--- a/T3D/T3D/Quaternion.h
+++ b/T3D/T3D/Quaternion.h
@@ -7,9 +7,7 @@
 // Quaternion.h
 //
 // Quaternion class - all implementation is in the header
-
-#ifndef QUATERNION_H
-#define QUATERNION_H
+#pragma once
 	
 #include "Vector3.h"
 #include "Matrix3x3.h"
@@ -396,6 +394,3 @@ namespace T3D {
         }
 	};
 }
-
-#endif 
-

--- a/T3D/T3D/Renderer.h
+++ b/T3D/T3D/Renderer.h
@@ -7,27 +7,22 @@
 // renderer.h
 //
 // Abstract base class for all rendering operations
+#pragma once
 
-#ifndef RENDERER_H
-#define RENDERER_H
-
-#include "Transform.h"
-#include "GameObject.h"
+#include <string>
+#include <vector>
+#include "DefaultDebugOptions.h"
 #include "Light.h"
-#include "Mesh.h"
-#include "Texture.h"
 
 namespace T3D
 {
-	#define WINDOW_WIDTH		1024
-	#define	WINDOW_HEIGHT		640
-
-	// Width of the window provided by the OS layer, in pixels.
-	const uint32_t WindowWidth = WINDOW_WIDTH;
-	// Height of the window provided by the OS layer, in pixels.
-	const uint32_t WindowHeight = WINDOW_HEIGHT;
-
+	class Transform;
+	class Mesh;
 	class Camera;
+	class GameObject;
+	class Texture;
+	class Colour;
+	class Material;
 
 	//! Generic class for renderers
 	/*! The render is responsible for managing materials and drawing meshes
@@ -36,13 +31,13 @@ namespace T3D
 	class Renderer
 	{
 	public:
+
 		static const int PR_SKYBOX = 0;			//! Priority level for skybox (drawn first)
 		static const int PR_TERRAIN = 2;		//! Priority level for terrain
 		static const int PR_OPAQUE = 4;			//! Priority level for standard opaque meshes
 		static const int PR_TRANSPARENT = 6;	//! Priority level for transparent meshes
 		static const int PR_OVERLAY = 8;		//! Priority level for overlays (drawn last)
 		static const int PRIORITY_LEVELS = 10; 
-
 
 		Renderer(void);
 		virtual ~Renderer(void);
@@ -94,9 +89,13 @@ namespace T3D
 
 		bool showWireframe, showPoints, showGrid, showAxes;
 
+		// Width of the window provided by the OS layer, in pixels.
+		uint32_t WindowWidth = DefaultDebugOptions::DefaultWindowWidth;
+
+		// Height of the window provided by the OS layer, in pixels.
+		uint32_t WindowHeight = DefaultDebugOptions::DefaultWindowHeight;
+
 	private:
 		std::vector<Material*> materials[PRIORITY_LEVELS];
 	};
 }
-
-#endif

--- a/T3D/T3D/RotateBehaviour.cpp
+++ b/T3D/T3D/RotateBehaviour.cpp
@@ -8,26 +8,13 @@
 //
 // Simple behaviour to rotate an object
 
-#include "rotatebehaviour.h"
+#include "RotateBehaviour.h"
 #include "GameObject.h"
 #include "Transform.h"
-#include "Math.h"
 
 namespace T3D
 {
-
-	RotateBehaviour::RotateBehaviour(Vector3 r)
-	{
-		rotation = r;
-	}
-
-
-	RotateBehaviour::~RotateBehaviour(void)
-	{
-	}
-
-	
-	void RotateBehaviour::update(float dt){
+	void RotateBehaviour::update(float dt) {
 		gameObject->getTransform()->rotate(rotation*dt);
 	}
 

--- a/T3D/T3D/RotateBehaviour.h
+++ b/T3D/T3D/RotateBehaviour.h
@@ -7,13 +7,10 @@
 // RotateBehaviour.h
 //
 // Simple behaviour to rotate an object
+#pragma once
 
-#ifndef ROTATEBEHAVIOUR_H
-#define ROTATEBEHAVIOUR_H
-
-#include "component.h"
+#include "Component.h"
 #include "Vector3.h"
-#include "Quaternion.h"
 
 namespace T3D
 {
@@ -22,8 +19,8 @@ namespace T3D
 		public Component
 	{
 	public:
-		RotateBehaviour(Vector3);
-		~RotateBehaviour(void);
+		RotateBehaviour(Vector3 r) : rotation(r) { }
+		~RotateBehaviour(void) = default;
 		
 		virtual void update(float dt);
 	protected:
@@ -31,5 +28,3 @@ namespace T3D
 	};
 
 }
-
-#endif

--- a/T3D/T3D/Shader.cpp
+++ b/T3D/T3D/Shader.cpp
@@ -11,12 +11,28 @@
 #include <iostream>
 #include <fstream>
 #include "Shader.h"
+#include "Logger.h"
 
-namespace T3D{
+namespace T3D {
 
+	/*
+	 * \param vertFileName Path to vertex shader source
+	 * \param vertFileName Path to fragment shader source
+	 *
+	 * \note These are relative to T3D's starting directory - in Visual Studio, this will be from 'Debug'
+	 * \note If you cannot load shader source code, check the console and log file for errors!
+	 */
 	Shader::Shader(std::string vertFilename, std::string fragFilename)
 	{
-		//std::cout << "Loading shader source...\n";
+		logger::Log(priority::Tracing,
+					output_stream::File,
+					category::Video,
+					"Loading shader source...\n\t"
+					"Vertex file: %s\n\t"
+					"Fragment file: %s\n",
+					vertFilename.c_str(),
+					fragFilename.c_str());
+
 		std::ifstream vertfile(vertFilename);
 		std::ifstream fragfile(fragFilename);
 		
@@ -33,11 +49,6 @@ namespace T3D{
 			std::getline(fragfile, line);
 			fragSource.append(line + "\n");
 		}
-	}
-
-
-	Shader::~Shader(void)
-	{
 	}
 
 }

--- a/T3D/T3D/Shader.h
+++ b/T3D/T3D/Shader.h
@@ -12,17 +12,22 @@
 
 #include <string>
 
-namespace T3D{
+namespace T3D {
 
+	//! Base class for Shaders.
 	class Shader
 	{
 	public:
+		//! \brief Create renderer-friendly Shader source code from Vertex and Fragment sources.
 		Shader(std::string vertFilename, std::string fragFilename);
-		virtual ~Shader(void);
+		
+		//! \brief Destroy shader (trivially);
+		virtual ~Shader(void) = default;
 		
 		virtual void compileShader() = 0;
-		virtual void bindShader() = 0;
-		virtual void unbindShader() = 0;
+		virtual void bindShader()    = 0;
+		virtual void unbindShader()  = 0;
+
 
 	protected:
 		std::string vertSource, fragSource;

--- a/T3D/T3D/ShaderTest.cpp
+++ b/T3D/T3D/ShaderTest.cpp
@@ -12,6 +12,10 @@
 #include "Camera.h"
 #include "Sphere.h"
 #include "GLShader.h"
+#include "GameObject.h"
+#include "Material.h"
+#include "Renderer.h"
+#include "Transform.h"
 
 namespace T3D{
 

--- a/T3D/T3D/ShaderTest.h
+++ b/T3D/T3D/ShaderTest.h
@@ -7,12 +7,13 @@
 // ShaderTest.cpp
 //
 // A simple application used for testing lighting shaders
-
 #pragma once
-#include "winglapplication.h"
+
+#include "WinGLApplication.h"
 
 namespace T3D{
 
+	//! \brief For testing OpenGL Lighting shaders.
 	class ShaderTest :
 		public WinGLApplication
 	{

--- a/T3D/T3D/Sound.cpp
+++ b/T3D/T3D/Sound.cpp
@@ -9,10 +9,16 @@
 // Simple class used for playing short sound files.  Uses FMod: www.fmod.org
 
 #include "Sound.h"
+#include "Logger.h"
 
 namespace T3D{
 
 	void Sound::play(){
+		logger::Log(priority::Tracing,
+					output_stream::File,
+					category::Audio,
+					"Started playing sound...");
+
 		soundManager->system->playSound(FMOD_CHANNEL_FREE, theSound, true, &channel);
 		channel->setVolume(volume); 
 		channel->setPaused(false);

--- a/T3D/T3D/Sound.h
+++ b/T3D/T3D/Sound.h
@@ -10,12 +10,12 @@
 
 #pragma once
 
-#include <string>
 #include "fmod/fmod.hpp"
 #include "SoundManager.h"
 
-namespace T3D{
+namespace T3D {
 
+	//! \brief Play and adjust sounds loaded by a SoundManager.
 	class Sound
 	{
 	friend class SoundManager;

--- a/T3D/T3D/SoundManager.h
+++ b/T3D/T3D/SoundManager.h
@@ -10,21 +10,24 @@
 
 #pragma once
 
+#include <string>
+
 #include "fmod/fmod.hpp"
 #include "fmod/fmod_errors.h"
 
-namespace T3D{
+namespace T3D {
 	
 	class Sound;
 	class Music;
 
+	//! \brief Create, load and update sounds and music.
 	class SoundManager
 	{
 	friend class Sound;
 	friend class Music;
 	public:
-		SoundManager(void);
-		virtual ~SoundManager(void);
+		SoundManager(void) : system(nullptr) { }
+		virtual ~SoundManager(void) = default;
 
 		void init();
 		void update();

--- a/T3D/T3D/SoundTestTask.h
+++ b/T3D/T3D/SoundTestTask.h
@@ -13,7 +13,7 @@
 #include "Sound.h"
 #include "Music.h"
 
-namespace T3D{
+namespace T3D {
 
 	class SoundTestTask :
 		public Task

--- a/T3D/T3D/Sphere.cpp
+++ b/T3D/T3D/Sphere.cpp
@@ -4,14 +4,12 @@
 //
 // Author: Robert Ollington
 //
-// sphere.cpp
+// Sphere.cpp
 //
 // A simple sphere mesh with variable size and polygon density
 
-#include <math.h>
-#include "sphere.h"
+#include "Sphere.h"
 #include "Math.h"
-#include <iostream>
 
 namespace T3D{
 
@@ -72,11 +70,6 @@ namespace T3D{
 		calcNormals();
 		
 		calcUVSphere();
-	}
-
-
-	Sphere::~Sphere(void)
-	{
 	}
 
 }

--- a/T3D/T3D/Sphere.h
+++ b/T3D/T3D/Sphere.h
@@ -4,25 +4,30 @@
 //
 // Author: Robert Ollington
 //
-// sphere.h
+// Sphere.h
 //
-// A simple sphere mesh with variable size and polygon density
+// A simple sphere mesh with variable size and polygon density.
+#pragma once
 
-#ifndef SPHERE_H
-#define SPHERE_H
+#include "Mesh.h"
 
-#include "mesh.h"
+namespace T3D {
 
-namespace T3D{
-
+	// \! Simple parametric Sphere mesh.
 	class Sphere :
 		public Mesh
 	{
 	public:
+		//! \brief Create Sphere.
+		/*
+		 * \param radius	Radius of sphere
+		 * \param density	Number of planes cubed that defines a Sphere.
+		 *
+		 */
 		Sphere(float radius, int density = 8);
-		virtual ~Sphere(void);
+
+		//! \brief Destroy Sphere (trivially)
+		virtual ~Sphere(void) = default;
 	};
 
 }
-
-#endif

--- a/T3D/T3D/Sweep.cpp
+++ b/T3D/T3D/Sweep.cpp
@@ -1,47 +1,52 @@
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// Sweep.cpp
+//
+// Create 3D meshes procedurally by moving ('sweeping') a 2D profile through space.
+
 #include "Sweep.h"
 
 namespace T3D
 {
-
-	/*! Constructs a mesh from a (usually 2D) profile by sweeping the profile along a SweepPath
-		\param points		The points defining the profile
-		\param path		Defines the path to sweep along
-		\param closed		If true, the last profile along the path will be connected back to the first profile
-		*/
+	/*
+	 * \param points	Container of points defining a profile
+	 * \param path		Path in world space to sweep profile along 
+	 * \param closed	Loop the end of path back to beginning or not
+	 */
 	Sweep::Sweep(std::vector<Vector3> &profilePoints, SweepPath &path, bool closed) : Mesh()
 	{
 		/* Add an extra step to the sweep path if its closed */
-		if (closed) 
-		{
-			path.addTransform(path[0]);
-		}
+		if (closed) path.addTransform(path[0]);
 
 		// MSVC cannot inline `size()` calls for a vector that is mutable, as its possible
 		// for the size to change during a loop body.
 		// So, grab the sizes here and use them throughout the rest of the function as we know they don't change.
-		const uint32_t pointsInPath      = path.size();
-		const uint32_t verticesInProfile = profilePoints.size();
+		const uint32_t pp = path.size();
+		const uint32_t vp = profilePoints.size();
 
-		int numVerts = pointsInPath * verticesInProfile;
+		int numVerts = pp * vp;
 		int numQuads = numVerts;
 
-			       /* triangles not used */
+	    /* triangles = 0 as not used */
 		initArrays(numVerts, 0, numQuads);
 		
 		int vpos = 0;
 		int fpos = 0;
 
-		for (uint32_t i = 0; i < pointsInPath; i++){
-			for(uint32_t j = 0; j < verticesInProfile; j++)
-			{
+		for (uint32_t i = 0; i < pp; i++) {
+			for (uint32_t j = 0; j < vp; j++) {
 				Vector3 v = path[i].transformPoint(profilePoints[j]);
 				setVertex(vpos++,v.x,v.y,v.z);
 
 				setQuadFace(fpos++,
-							( (j + 0)                      + (i + 0)                  * verticesInProfile),
-							(((j + 1) % verticesInProfile) + (i + 0)                  * verticesInProfile),
-							(((j + 1) % verticesInProfile) + ((i + 1) % pointsInPath) * verticesInProfile),
-							( (j + 0)                      + ((i + 1) % pointsInPath) * verticesInProfile));
+							(j + 0)      + ( i + 0)       * vp,
+							(j + 1) % vp + ( i + 0)       * vp,
+							(j + 1) % vp + ((i + 1) % pp) * vp,
+							(j + 0)      + ((i + 1) % pp) * vp);
 			}
 		}
 
@@ -49,7 +54,7 @@ namespace T3D
 		calcNormals();		
 		
 		int pos = 0;
-		for (int i=0; i<numVerts; i++){
+		for (int i=0; i<numVerts; i++) {
 			colors[pos++] = 1; colors[pos++] = 0; colors[pos++] = 1; colors[pos++] = 1;
 		}
 	}

--- a/T3D/T3D/Sweep.h
+++ b/T3D/T3D/Sweep.h
@@ -1,25 +1,36 @@
-#ifndef SWEEP_H
-#define SWEEP_H
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// Sweep.h
+//
+// Create 3D meshes procedurally by moving ('sweeping') a 2D profile through space.
+#pragma once
 
 #include <vector>
-#include "mesh.h"
+
+#include "Mesh.h"
 #include "Vector3.h"
 #include "SweepPath.h"
 
 namespace T3D
 {
 	//! Creates a 3D Mesh from a (usually 2D) profile by sweeping the profile along a SweepPath
-	/*! The profile is defined by a list of Vector3's (2D profile recommended). The SweepPath is defined by a list of Transform's.  
-	  Care must be taken to ensure that the profile and path define a valid mesh - no error checking is performed
-	  \author	Robert Ollington
+	/*! 
+	 * The profile is defined by a list of Vector3's (2D profile recommended). The SweepPath is defined by a list of Transforms.  
+	 *
+	 * \note Care must be taken to ensure that the profile and path define a valid mesh - no error checking is performed
+	 * \author	Robert Ollington
 	  */
 	class Sweep :
 		public Mesh
 	{
 	public:
+		// \brief Create Sweep from profile and path.
 		Sweep(std::vector<Vector3> &points, SweepPath &path, bool closed = false);
+
 		virtual ~Sweep(void) = default;
 	};
 }
-
-#endif

--- a/T3D/T3D/SweepPath.cpp
+++ b/T3D/T3D/SweepPath.cpp
@@ -1,31 +1,40 @@
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// SweepPath.h
+//
+// Helpful operations for creating common sweep paths such as circles.
+
 #include "SweepPath.h"
-#include <math.h>
 
 namespace T3D{
 
-	SweepPath::SweepPath(void)
-	{
-	}
-
-
-	SweepPath::~SweepPath(void)
-	{
-	}
-
-	Transform SweepPath::operator[](int index) const{
+	Transform SweepPath::operator[](int index) const {
 		return path[index];
 	}
 
-	void SweepPath::addTransform(Transform &t){
+	/*
+	 * \param t Transform to add
+	 */
+	void SweepPath::addTransform(Transform &t) {
 		path.push_back(t);
 	}
 
+	/*
+	 * \param radius Path radius
+	 * \param density Vertices in path
+	 *
+	 * \note This will *clear* any transforms that are already in the Path!
+	 */
 	void SweepPath::makeCirclePath(float radius, int density){
 		path.clear();
 		for (int i=0; i<density; i++){
 			Transform t;
 			float angle = Math::TWO_PI*i/density;
-			t.setLocalPosition(Vector3(radius*cosf(angle),0,radius*sinf(angle)));
+			t.setLocalPosition(Vector3(radius*cosf(angle),0, radius*std::sinf(angle)));
 			t.setLocalRotation(Quaternion(Vector3(0,-angle,0)));
 			path.push_back(t);
 		}

--- a/T3D/T3D/SweepPath.h
+++ b/T3D/T3D/SweepPath.h
@@ -1,6 +1,13 @@
-
-#ifndef SWEEPPATH_H
-#define SWEEPPATH_H
+// =========================================================================================
+// KXG363 - Advanced Games Programming, 2012
+// =========================================================================================
+//
+// Author: Robert Ollington
+//
+// SweepPath.h
+//
+// Helpful operations for creating common sweep paths such as circles.
+#pragma once
 
 #include <vector>
 #include "Transform.h"
@@ -10,19 +17,25 @@ namespace T3D
 	class SweepPath
 	{
 	public:
-		SweepPath(void);
-		virtual ~SweepPath(void);
+		//! \brief Create SweepPath (trivially)
+		SweepPath(void) = default;
 
-		Transform operator[](int index) const;
+		//! \brief Destroy SweepPath (trivially)
+		virtual ~SweepPath(void) = default;
+
+		//! \brief Add Transform to end of the Path.
 		void addTransform(Transform &t);
+
+		//! \brief Get number of Transforms in the path.
 		uint32_t size(){ return path.size(); }
 
+		//! \brief Create a circular path.
 		void makeCirclePath(float radius, int density);
+
+		//! \brief Get a Transform from the path.
+		Transform operator[](int index) const;
 
 	protected:
 		std::vector<Transform> path;
 	};
 }
-
-#endif
-

--- a/T3D/T3D/T3D.vcxproj
+++ b/T3D/T3D/T3D.vcxproj
@@ -30,6 +30,7 @@
     <ClCompile Include="Input.cpp" />
     <ClCompile Include="KeyboardController.cpp" />
     <ClCompile Include="Light.cpp" />
+    <ClCompile Include="Logger.cpp" />
     <ClCompile Include="LookAtBehaviour.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Material.cpp" />
@@ -85,6 +86,7 @@
     <ClInclude Include="Input.h" />
     <ClInclude Include="KeyboardController.h" />
     <ClInclude Include="Light.h" />
+    <ClInclude Include="Logger.h" />
     <ClInclude Include="LookAtBehaviour.h" />
     <ClInclude Include="Material.h" />
     <ClInclude Include="Math.h" />

--- a/T3D/T3D/T3D.vcxproj.filters
+++ b/T3D/T3D/T3D.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="ParticleGravity.cpp">
       <Filter>Source Files\Component</Filter>
     </ClCompile>
+    <ClCompile Include="Logger.cpp">
+      <Filter>Source Files\Miscellaneous</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Mesh.h">
@@ -388,6 +391,9 @@
     </ClInclude>
     <ClInclude Include="DefaultDebugOptions.h">
       <Filter>Header Files\Application</Filter>
+    </ClInclude>
+    <ClInclude Include="Logger.h">
+      <Filter>Header Files\Miscellaneous</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/T3D/T3D/T3DApplication.h
+++ b/T3D/T3D/T3DApplication.h
@@ -4,27 +4,23 @@
 //
 // Author: Robert Ollington
 //
-// t3dapplication.cpp
+// T3Dapplication.cpp
 //
 // Abstract base class for a T3D application
 // Stores reference to root transform of scene graph and list of tasks
+#pragma once
 
-#ifndef T3DAPPLICATION_H
-#define T3DAPPLICATION_H
-
-
-#include "Transform.h"
-#include "renderer.h"
-#include "Font.h"
 #include <list>
-#include "SoundManager.h"
-
-using namespace std;
 
 namespace T3D
 {
 	class Task;
+	class Renderer;
+	class Transform;
+	class font;
+	class SoundManager;
 
+	//! \brief Base class for T3D driver applications, such as WinGLApplication.
 	class T3DApplication
 	{
 	public:
@@ -32,7 +28,7 @@ namespace T3D
 		virtual ~T3DApplication(void);
 
 		virtual bool init() = 0;
-		virtual int run() = 0;
+		virtual int  run() = 0;
 		virtual void quit() = 0;
 		virtual void updateTasks();
 		virtual void updateComponents(Transform *t);
@@ -59,6 +55,3 @@ namespace T3D
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/T3DTest.cpp
+++ b/T3D/T3D/T3DTest.cpp
@@ -4,11 +4,11 @@
 //
 // Author: Robert Ollington
 //
-// t3dtest.cpp
+// T3DTest.cpp
 //
-// Example t3dapplication
+// Example T3Dapplication
 
-#include "t3dtest.h"
+#include "T3DTest.h"
 #include "Cube.h"
 #include "PlaneMesh.h"
 #include "Sphere.h"
@@ -28,6 +28,9 @@
 #include "Math.h"
 #include "Sweep.h"
 #include "SweepPath.h"
+
+#include "Light.h"
+#include "Renderer.h"
 
 namespace T3D {
 
@@ -95,11 +98,7 @@ namespace T3D {
 
 		//Create a camera
 		GameObject *camObj = new GameObject(this);
-		float near   = 0.1f;
-		float far    = 500.0f;
-		float fovy   = 45.0f;
-		float aspect = 1.6f;
-		renderer->camera = new Camera(near, far, fovy, aspect);
+		renderer->camera = new Camera(0.3, 300.0, 45.0, 1.6);
 		camObj->getTransform()->setLocalPosition(Vector3(0,0,20));
 		camObj->getTransform()->setLocalRotation(Vector3(0,0,0));
 		camObj->setCamera(renderer->camera);
@@ -139,13 +138,13 @@ namespace T3D {
 		//Create an empty node to use as a rotation point
 		GameObject *rotateOrigin = new GameObject(this);
 		rotateOrigin->getTransform()->setParent(root);
-		//rotateOrigin->addComponent(new RotateBehaviour(Vector3(0,1,0)));
-		
+		rotateOrigin->addComponent(new RotateBehaviour(Vector3(0,1,0)));
+	
 		//Create a torus using the Sweep class as a child of rotateOrigin
 		SweepPath sp;
 		sp.makeCirclePath(2,32);
 		GameObject *torus = new GameObject(this);
-		vector<Vector3> points;
+		std::vector<Vector3> points;
 		points.push_back(Vector3(0.2f,0.0f,0.0f));
 		points.push_back(Vector3(0.14f,0.14f,0.0f));
 		points.push_back(Vector3(0.0f,0.2f,0.0f));
@@ -171,15 +170,16 @@ namespace T3D {
 		//Create some animation for the sphere and torus
 		Animation *anim = new Animation(10.0);
 		torus->addComponent(anim);
-		anim->addKey("Sphere",10.0,Quaternion(),Vector3(0,5,0));
 		anim->addKey("Sphere",0,Quaternion(),Vector3(0,5,0));
-		anim->addKey("Sphere",7.0,Quaternion(),Vector3(0,0,0));
 		anim->addKey("Sphere",5.0,Quaternion(),Vector3(0,-5,0));
-		anim->addKey("Torus",10.0,Quaternion(),Vector3(10,0,0));
+		anim->addKey("Sphere",7.0,Quaternion(),Vector3(0,0,0));
+		anim->addKey("Sphere",10.0,Quaternion(),Vector3(0,5,0));
 		anim->addKey("Torus",0,Quaternion(),Vector3(10,0,0));
-		anim->addKey("Torus",7.0,Quaternion(),Vector3(15,0,0));
 		anim->addKey("Torus",5.0,Quaternion(Vector3(0,0,Math::HALF_PI)),Vector3(5,0,0));
+		anim->addKey("Torus",7.0,Quaternion(),Vector3(15,0,0));
+		anim->addKey("Torus",10.0,Quaternion(),Vector3(10,0,0));
 		anim->loop(true);	
+		anim->play();	
 		
 		//Add a cube to act as a source for particle system
 		GameObject *cubeF = new GameObject(this);
@@ -193,6 +193,7 @@ namespace T3D {
 		// A simple fireworks fountain using the particle system
 		ParticleEmitter *particleSys = new ParticleEmitter(10.0f, 1.0f, 20.0f, 2.0f, 3.0f, 3.0f);
 		cubeF->addComponent(particleSys);			// make cube source of particles
+
 		// Create a pool of particles
 		for (int i = 0; i<100; i++)
 		{

--- a/T3D/T3D/T3DTest.h
+++ b/T3D/T3D/T3DTest.h
@@ -7,24 +7,21 @@
 // t3dtest.h
 //
 // Example t3dapplication
+#pragma once
 
-#ifndef T3DTEST
-#define T3DTEST
+#include "WinGLApplication.h"
 
-#include "winglapplication.h"
-
-namespace T3D{
-
-class T3DTest :
-	public WinGLApplication
+namespace T3D
 {
-public:
-	T3DTest(void)  = default;
-	~T3DTest(void) = default;
 
-	bool init();
-};
+	class T3DTest :
+		public WinGLApplication
+	{
+	public:
+		T3DTest(void)  = default;
+		~T3DTest(void) = default;
+
+		bool init();
+	};
 
 }
-#endif
-

--- a/T3D/T3D/Task.cpp
+++ b/T3D/T3D/Task.cpp
@@ -9,19 +9,7 @@
 // Abstract base class for tasks
 // Ideas from http://www.gamedev.net/page/resources/_/technical/game-programming/enginuity-part-iv-r1973
 
-#include "Task.h"
-
 namespace T3D
 {
-
-	Task::Task(T3DApplication* app) :app(app)
-	{
-		finished = false;
-	}
-
-
-	Task::~Task(void)
-	{
-	}
-
+	/* Abstract base class: Implementation not provided */
 }

--- a/T3D/T3D/Task.h
+++ b/T3D/T3D/Task.h
@@ -8,27 +8,42 @@
 //
 // Abstract base class for tasks
 // Ideas from http://www.gamedev.net/page/resources/_/technical/game-programming/enginuity-part-iv-r1973
+#pragma once
 
-#ifndef TASK_H
-#define TASK_H
-
+#include <string>
 #include "T3DApplication.h"
 
 namespace T3D
 {
-
+	//! \brief Timed, searchable application-level tasks.
+	/*
+	 * T3D Tasks are the smallest unit of work T3DApplication instances can schedule.
+	 * Tasks can do arbitrary things and have access to the rendering context. 
+	 * For example, 2D drawing tasks and debug message tasks.
+	 *
+	 * A common way of implementing interlinked movies/animations is to subclass Task,
+	 * creating a centralized way to tick many different GameObjects - this is covered in the tutorials.
+	 */
 	class Task
 	{
 	public:
-		Task(T3DApplication *app);
-		virtual ~Task(void);
+		//! \brief Create Task
+		Task(T3DApplication *app) : app(app), 
+									finished(false) { }
 
+		//! \brief Destroy Task (trivially)
+		virtual ~Task(void) = default;
+
+		//! \brief Tick Task.
 		virtual void update(float dt) = 0;
 
-		bool getFinished() { return finished; }
+		// Accessors
+		bool getFinished()              { return finished; }
 		void setFinished(bool finished) { this->finished = finished; }
-		std::string& getName() { return name; }
+
+		std::string& getName()         { return name; }
 		void setName(const char *name) { this->name = name; }
+
 
 	private:
 		std::string name;					// task name
@@ -39,6 +54,3 @@ namespace T3D
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/Terrain.cpp
+++ b/T3D/T3D/Terrain.cpp
@@ -9,9 +9,8 @@
 // Component used for creating terrains - from an image file, or procedurally.
 
 #include <sdl\SDL.h>
-#include "terrain.h"
+#include "Terrain.h"
 #include "PlaneMesh.h"
-#include "Material.h"
 #include "Math.h"
 #include "GameObject.h"
 #include "Transform.h"

--- a/T3D/T3D/Terrain.h
+++ b/T3D/T3D/Terrain.h
@@ -7,23 +7,22 @@
 // Terrain.h
 //
 // Component used for creating terrains - from an image file, or procedurally.
-
-#ifndef TERRAIN_H
-#define TERRAIN_H
+#pragma once
 
 #include <string>
-#include "component.h"
+
+#include "Component.h"
 #include "Vector3.h"
 
-namespace T3D{
+namespace T3D {
 
-	//! A triangle mesh terrain class
-	/*! Can create a terrain from a texture or procudurally generate a fractal terrain
-	  \todo		Consider refactoring this class so that it is a subclass of Mesh
-	  
-	  \author	Robert Ollington
-	  */
-
+	//! \brief Create Terrain from heightmaps, or procedurally.
+	/*! 
+	 * Can create a terrain from a texture or procudurally generate a fractal terrain
+	 * \todo Consider refactoring this class so that it is a subclass of Mesh
+	 * 
+	 * \author	Robert Ollington
+	 */
 	class Terrain :
 		public Component
 	{
@@ -41,6 +40,3 @@ namespace T3D{
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/TerrainFollower.cpp
+++ b/T3D/T3D/TerrainFollower.cpp
@@ -12,23 +12,18 @@
 #include "Transform.h"
 #include "GameObject.h"
 
-namespace T3D{
-
-	TerrainFollower::TerrainFollower(Terrain* t, float h)
-	{
-		terrain = t;
-		height = h;
-	}
-
-
-	TerrainFollower::~TerrainFollower(void)
-	{
-	}
-
-	void TerrainFollower::update(float dt){
+namespace T3D 
+{
+	/*
+	 * \param dt Change in time
+	 *
+	 * \note The order in which T3D components update is _undefined_; beware multiple components updating world positions!
+	 */
+	void TerrainFollower::update(float dt) {
 		Vector3 currentPos = gameObject->getTransform()->getWorldPosition();
 		currentPos.y = terrain->getHeight(currentPos) + height;
 		gameObject->getTransform()->setWorldPosition(currentPos);
+
 		//Vector3 newPos = gameObject->getTransform()->getWorldPosition();
 		//std::cout << currentPos << "->" << newPos << "\n";
 	}

--- a/T3D/T3D/TerrainFollower.h
+++ b/T3D/T3D/TerrainFollower.h
@@ -7,22 +7,30 @@
 // TerrainFollower.h
 //
 // Simple behaviour for basic terrain following
+#pragma once
 
-#ifndef TERRAINFOLLOWER_H
-#define TERRAINFOLLOWER_H
-
-#include "component.h"
+#include "Component.h"
 #include "Terrain.h"
 
-namespace T3D{
-
+namespace T3D 
+{
+	//! \brief Component for following the surface of Terrain with respect to height.
+	/*
+	 * \note This looks best for convex Terrain with smooth slopes and GameObjects best visualized with bounding boxes.
+	 */
 	class TerrainFollower :
 		public Component
 	{
 	public:
-		TerrainFollower(Terrain* t, float h);
-		virtual ~TerrainFollower(void);
+		//! \brief Create TerrainFollower
+		/*
+		 * \param t Terrain to 'follow'.
+		 */
+		TerrainFollower::TerrainFollower(Terrain* t, float h) : terrain(t),
+															    height (h)  { }
+		virtual ~TerrainFollower(void) = default;
 
+		//! \brief Tick the TerrainFollower, updating the GameObject's height.
 		virtual void update(float dt);
 
 	private:
@@ -30,5 +38,3 @@ namespace T3D{
 		float height;
 	};
 }
-
-#endif

--- a/T3D/T3D/Texture.cpp
+++ b/T3D/T3D/Texture.cpp
@@ -8,16 +8,15 @@
 //
 // Class for loading, storing and manipulating textures
 
-#include <iostream>
 #include <sdl\SDL_image.h>
+#include <assert.h>
+
 #include "Texture.h"
 #include "Math.h"
-
-#include <assert.h>
+#include "Logger.h"
 
 namespace T3D
 {
-
 	Texture::Texture(int width, int height, bool continuousTone, bool mipmap)
 	{
 		Uint32 rmask, gmask, bmask, amask;
@@ -37,8 +36,12 @@ namespace T3D
 		}
 
 		image = SDL_CreateRGBSurface(0, width, height, 32,rmask, gmask, bmask, amask);
-		if(image == NULL) {
-			std::cout << "CreateRGBSurface failed: %s\n" << SDL_GetError() << "\n";
+		if(image == NULL) 
+		{
+			logger::Log(priority::Error, 
+						output_stream::All, 
+						category::Video, 
+						"SDL_CreateRGBSurface failed :: %s\n", SDL_GetError());
 		}
 
 		this->continuousTone = continuousTone;
@@ -49,12 +52,13 @@ namespace T3D
 
 	Texture::Texture(std::string filename, bool continuousTone, bool mipmap)
 	{
-		if ( image = IMG_Load(filename.c_str()))			// supports lots of file formats
-		//if ( image = SDL_LoadBMP(filename.c_str()) )
+		if (image = IMG_Load(filename.c_str()))			// supports lots of file formats
 		{
-			std::cout << "loaded: " << filename << "\n";
-		} else {
-			std::cout << "could not load: " << filename << "\n";
+			logger::Log(priority::Tracing, output_stream::File, category::Video, "Loaded texture : %s\n", filename.c_str());
+		} 
+		else 
+		{
+			logger::Log(priority::Error, output_stream::All, category::Video, "Could not load texture : %s\n",  filename.c_str());
 		}
 
 		this->continuousTone = continuousTone;
@@ -67,6 +71,89 @@ namespace T3D
 	{
 		SDL_FreeSurface(image);
 	}
+
+	/*
+	 * \param x	x position (leftmost)
+	 * \param y y position (uppermost)
+	 * \param text	message, assumed null-terminated c-string 
+	 * \param c	RGBA text colour
+	 * \param font handle to font family & size pair
+	 *
+	 * \note The origin of a Texture's surface has `y_max` at the top.
+	 */
+	void Texture::writeText(int         x, 
+							int         y, 
+							const char *text, 
+							Colour      c, 
+							TTF_Font   *font)
+	{
+		SDL_Surface *temp;
+		SDL_Color color;
+
+		color.r = c.r;
+		color.g = c.g;
+		color.b = c.b;
+	
+		/* Use SDL_TTF to render our text */
+		temp = TTF_RenderText_Blended(font, text, color);
+	
+		SDL_Rect destRect;
+		destRect.x = x;
+		destRect.y = y;
+		destRect.w = temp->w;
+		destRect.h = temp->h;
+
+		SDL_BlitSurface(temp, 0, image, &destRect);
+	
+		SDL_FreeSurface(temp);
+	}
+	
+	/*
+	 * \param x	pixel x
+	 * \param y	pixel y
+	 *
+	 * \note Assumes `(0 > x > surface_width)`, `(0 > y > surface_height)`;
+	 */
+	Colour Texture::getPixel(int x, int y){
+		return Colour(((Uint32 *)image->pixels)[x*(image->pitch/sizeof(unsigned int)) + y]); 
+	}
+
+	/*
+	 * \param x	pixel x
+	 * \param y	pixel y
+	 * \param c	pixel colour
+	 *
+	 * \note This will crash if `(0 > x > surface_width)`, `(0 > y > surface_height)`;
+	 * \note `DrawTask` provides a bounds-checked, efficient function `pushPixel` to draw many pixels onto a surface and diagnose errors.
+	 */
+	void Texture::plotPixel(int x, int y, Colour c){
+		
+		if( SDL_MUSTLOCK(image) )
+			SDL_LockSurface(image);
+
+		Uint32 colour = SDL_MapRGBA(image->format, c.r, c.g, c.b, c.a);
+		Uint8 * pixel = (Uint8*)image->pixels;
+		pixel += (y * image->pitch) + (x * sizeof(Uint32));
+		*((Uint32*)pixel) = colour;
+
+		
+		if( SDL_MUSTLOCK(image) )
+			SDL_UnlockSurface(image);
+	}
+
+	/*
+	 * \param c	surface colour
+	 * \note Asserts surface size is smaller than UINT16_MAX.
+	 */
+	void Texture::clear(Colour c){
+		Uint32 colour = SDL_MapRGBA(image->format, c.r, c.g, c.b, c.a);
+		assert(image->w < UINT16_MAX); // Keeps static analyzers happy.
+		assert(image->h < UINT16_MAX);
+
+		SDL_Rect all = {0, 0, uint16_t(image->w), uint16_t(image->h)};
+		SDL_FillRect(image, &all, colour);
+	}
+
 
 	void Texture::createFractal(Colour low, Colour high, float roughness, bool conserveHue){
 		int resolution = (image->w > image->h)?image->w:image->h; // use larger dimension
@@ -112,57 +199,6 @@ namespace T3D
 			delete []gdata;
 			delete []bdata;
 		}
-	}
-
-	void Texture::writeText(int x, int y, const char *text, Colour c, TTF_Font *font)
-	{
-		SDL_Surface *temp;
-		SDL_Color color;
-
-		color.r = c.r;
-		color.g = c.g;
-		color.b = c.b;
-	
-		/* Use SDL_TTF to render our text */
-		temp = TTF_RenderText_Blended(font, text, color);
-	
-		SDL_Rect destRect;
-		destRect.x = x;
-		destRect.y = y;
-		destRect.w = temp->w;
-		destRect.h = temp->h;
-
-		SDL_BlitSurface(temp, 0, image, &destRect);
-	
-		SDL_FreeSurface(temp);
-	}
-	
-	Colour Texture::getPixel(int x, int y){
-		return Colour(((Uint32 *)image->pixels)[x*(image->pitch/sizeof(unsigned int)) + y]); 
-	}
-
-	void Texture::plotPixel(int x, int y, Colour c){
-		
-		if( SDL_MUSTLOCK(image) )
-			SDL_LockSurface(image);
-
-		Uint32 colour = SDL_MapRGBA(image->format, c.r, c.g, c.b, c.a);
-		Uint8 * pixel = (Uint8*)image->pixels;
-		pixel += (y * image->pitch) + (x * sizeof(Uint32));
-		*((Uint32*)pixel) = colour;
-
-		
-		if( SDL_MUSTLOCK(image) )
-			SDL_UnlockSurface(image);
-	}
-
-	void Texture::clear(Colour c){
-		Uint32 colour = SDL_MapRGBA(image->format, c.r, c.g, c.b, c.a);
-		assert(image->w < UINT16_MAX);
-		assert(image->h < UINT16_MAX);
-
-		SDL_Rect all = {0, 0, uint16_t(image->w), uint16_t(image->h)};
-		SDL_FillRect(image, &all, colour);
 	}
 
 }

--- a/T3D/T3D/Texture.h
+++ b/T3D/T3D/Texture.h
@@ -7,56 +7,74 @@
 // Texture.h
 //
 // Class for loading, storing and manipulating textures
-
-#ifndef TEXTURE_H
-#define TEXTURE_H
+#pragma once
 
 #include <string>
-#include "sdl\sdl.h"
+#include <sdl\sdl.h>
 #include <sdl\SDL_ttf.h>
 #include "Colour.h"
 
 namespace T3D
 {
-
+	//! \brief Load, store and manipulate Textures.
+	/*
+	 * To use a Texture on a Mesh, it must be associated with a Material. Refer to T3Dtest for a lengthier example.
+	 * Textures maintain an internal surface that is not managed by a Renderer. 
+	 * This surface can be manipulated arbitrarily, for example by writing text to it, or plotting pixels.
+	 * 
+	 */
 	class Texture
 	{
 	public:
+		//! \brief Create Texture with initialized surface.
 		Texture(int width, int height, bool continuousTone = true, bool mipmap = false);
+
+		//! \brief Create Texture with initialized surface from image file.
 		Texture(std::string filename, bool continuousTone = true, bool mipmap = false);
+
+		//! \brief Destroy Texture and free surface.
 		virtual ~Texture(void);
 
-		void createFractal(Colour low, Colour high, float roughness, bool conserveHue = false);
+		//! \brief Write message onto texture coordinates using a provided font.
 		void writeText(int x, int y, const char *text, Colour c, TTF_Font *font);
 
-		int getWidth(){ return image->w; }
-		int getHeight(){ return image->h; }
-
+		//! \brief Get colour from pixel coordinates on screen.
 		Colour getPixel(int x, int y);
+
+		//! \brief Write a colour to a pixel coordinate.
 		void plotPixel(int x, int y, Colour c);
+
+		//! \brief Set the surface to a uniform colour and opacity.
 		void clear(Colour c);
 
-		unsigned int getID(){ return texid; }
-		void setID(unsigned int id){ texid = id; }
-		
-		int getNumberOfColors(){ return image->format->BytesPerPixel; }
+		// Renderer handle accessors
+		unsigned int getID()                { return texid; }
+		void         setID(unsigned int id) { texid = id; }
 
-		void* getPtr() { return image->pixels; }
+		// Scalar accessors
+		int getWidth()          { return image->w; }
+		int getHeight()         { return image->h; }
+		int getNumberOfColors() { return image->format->BytesPerPixel; }
+
+
+		// Buffer accessors
+		void* getPtr()            { return image->pixels; }
 		SDL_Surface* getSurface() { return image; }
 
-		bool isRGB(){ return (image->format->Rmask == 0x000000FF); }
 
+		// Predicates
+		bool isRGB(){ return (image->format->Rmask == 0x000000FF); }
 		bool getCountinuousTone() { return continuousTone; }
 		bool getMipmap() { return mipmap; }
 
+		// Other utilities.
+		void createFractal(Colour low, Colour high, float roughness, bool conserveHue = false);
+
 	private:
-		SDL_Surface *image;
-		unsigned int texid;
-		bool continuousTone;			// hint for choosing appropriate texture filtering
-		bool mipmap;					// generate automatic mipmaps when loading
+		SDL_Surface *image;			//! \brief Handle to SDL surface
+		uint32_t texid;				//! \brief Handle to renderer texture
+		bool continuousTone;		//! \brief Hint for choosing appropriate texture filtering
+		bool mipmap;				//! \brief Generate automatic mipmaps when loading
 	};
 
 }
-
-#endif
-

--- a/T3D/T3D/Transform.cpp
+++ b/T3D/T3D/Transform.cpp
@@ -10,11 +10,19 @@
 // Adapted from http://scriptionary.com/2009/02/17/simple-scene-graph-in-c/
 
 #include <queue>
+
 #include "Transform.h"
 #include "GameObject.h"
+#include "Logger.h"
 
 namespace T3D
 {
+	/*
+	 * This sets up local and world matrices for the transform, and resets clears update flags.
+	 *
+	 * \param p	Parent transform
+	 * \param n	Name of transform
+	 */
 	Transform::Transform(Transform* p, std::string n)
 	{
 		name = n;
@@ -38,66 +46,58 @@ namespace T3D
 	} 
 
 
+	/*
+	 * \note T3D manages GameObject memory by destroying children of a scenegraph, *then* destroying the GameObject and its components. 
+	 */
 	Transform::~Transform(void)
 	{
-		for(unsigned int i = 0; i < children.size(); ++i)
-		{
-			if(NULL != children[i])
-			{
-				delete children[i];
-			}
+		// NOTE:
+		// This leaks memory, as removeChild() invalidates the size of the calling node's subtree.
+		// Given a std::vector of nodes, V, when `V.erase` is called on any index n, V will shuffle elements from [n + 1...V.size()].
+		// This shuffle is to ensure elements are densely contiguous in memory. It means that as the indices increase, half the scene graph
+		// is not deleted. It just happens to not segfalt because the condition `V.size()` is not inlined. 
+		//
+		// A solution to this without a large refactoring of the component system would be to use std::shared_ptr or handles.
+		for (uint32_t child = 0; child < children.size(); child++) {
+			if (children[child]) delete children[child];
 		}
-		if (parent != NULL) {
-			parent->removeChild(this);
+
+		if (parent) {
+			parent->removeChild(this);  /* invalidates iterator of parent! */
 			parent = NULL;
 		}
 		children.clear();
+
 		delete gameObject;
 	}
 
-	
-	Matrix4x4 Transform::getLocalMatrix()
-	{
-		if (needLocalUpdate){
-			calcLocalMatrix();
-		}
-		return localMatrix;
-	}
-
-	Matrix4x4 Transform::getWorldMatrix()
-	{
-		if (needWorldUpdate){
-			update(false);
-		}
-		return worldMatrix;
-	}
-
+	/*
+	 * \param updateChildren Recursively update or not
+	 */
 	void Transform::update(bool updateChildren)
 	{	
-		if (needLocalUpdate){
-			calcLocalMatrix();
-		}
+		if (needLocalUpdate) calcLocalMatrix();
 
-		if(NULL != parent)
+		/* If this transform isn't the root, concatenate the parents matrix (operator '*' here)
+		   with ours after checking if parent needs an update.  Otherwise, this transform is
+		   the root and is synonymous with world space. */
+		if (parent) 
 		{
-			if (parent->needWorldUpdate){
-				parent->update(false);
-			}
+			if (parent->needWorldUpdate) parent->update(false);
 			worldMatrix = parent->worldMatrix*localMatrix;
-		} else {
+		} 
+		else 
+		{
 			worldMatrix = localMatrix;
 		}
 
 		needWorldUpdate = false;
 
-		if(updateChildren && !children.empty())
+		if(updateChildren)
 		{
-			for(unsigned int i = 0; i < children.size(); ++i)
+			for (auto child: children)
 			{
-				if(NULL != children[i])
-				{
-					children[i]->update(true);
-				}
+				child->update(true);
 			}
 		}
 	} 
@@ -114,25 +114,26 @@ namespace T3D
 		if (!needWorldUpdate)
 		{
 			needWorldUpdate = true;
-			if(!children.empty())
+			for (auto child: children)
 			{
-				for(unsigned int i = 0; i < children.size(); ++i)
-				{
-					if(NULL != children[i])
-					{
-						children[i]->setNeedWorldUpdate();
-					}
-				}
+				if (child) child->setNeedWorldUpdate();
 			}
 		}
 	}
 
 
+	/*
+	 * \param pos new local position
+	 */
 	void Transform::setLocalPosition(const Vector3& pos){
 		translationMatrix.setTrans(pos);
 		needLocalUpdate = true;
 		setNeedWorldUpdate();
 	}		
+
+	/*
+	 * \param pos new world position
+	 */
 	void Transform::setWorldPosition(const Vector3& pos){
 		if (needWorldUpdate){
 			update(false);
@@ -140,16 +141,29 @@ namespace T3D
 		if (parent)
 			setLocalPosition(pos - parent->getWorldPosition());
 	}
+
+	/*
+	 * \param rot new local rotation, as euler angles
+	 */
 	void Transform::setLocalRotation(const Vector3& rot){
 		rotationMatrix.fromEulerAngles(rot.y,rot.x,rot.z);
 		needLocalUpdate = true;
 		setNeedWorldUpdate();
 	}
+
+	/*
+	 * \param q new local rotation, as quaternion
+	 */
 	void Transform::setLocalRotation(Quaternion& q){
 		rotationMatrix = (Matrix3x3)q;
 		needLocalUpdate = true;
 		setNeedWorldUpdate();
 	}
+
+	/*
+	 * \param scl new scale
+	 * \note This may have strange behaviour for non-uniform scaling
+	 */
 	void Transform::setLocalScale(const Vector3& scl){
 		scaleMatrix[0][0] = scl.x;
 		scaleMatrix[1][1] = scl.y;
@@ -158,6 +172,9 @@ namespace T3D
 		setNeedWorldUpdate();
 	}
 		
+	/*
+	 * \param delta Movement terms
+	 */
 	const Vector3 Transform::getLocalPosition(){
 		return translationMatrix.getTrans();
 	}
@@ -190,36 +207,52 @@ namespace T3D
 		setNeedWorldUpdate();
 	}
 
+	/*
+	 * \param angle rotation angle
+	 */
 	void Transform::roll(const float angle)
     {
         rotate(Vector3(0,0,1), angle);
     }
-    //-----------------------------------------------------------------------
+
+	/*
+	 * \param angle rotation angle
+	 */
     void Transform::pitch(const float angle)
     {
         rotate(Vector3(1,0,0), angle);
     }
-    //-----------------------------------------------------------------------
+
+	/*
+	 * \param angle rotation angle
+	 */
     void Transform::yaw(const float angle)
     {
         rotate(Vector3(0,1,0), angle);
-
     }
-    //-----------------------------------------------------------------------
+
+	/*
+	 * \param axis Masked axis to move about
+	 * \param angle rotation angle
+	 */
     void Transform::rotate(const Vector3& axis, const float angle)
     {
         Quaternion q = Quaternion::fromAngleAxis(angle,axis);
         rotate(q);
     }
 
-	//-----------------------------------------------------------------------
+	/*
+	 * \param eulers rotation euler angles
+	 */
     void Transform::rotate(const Vector3& eulers)
     {
         Quaternion q = Quaternion(eulers);
         rotate(q);
     }
 
-    //-----------------------------------------------------------------------
+	/*
+	 * \param q rotation quaternion
+	 */
     void Transform::rotate(Quaternion& q)
     {
         rotationMatrix = rotationMatrix * (Matrix3x3)q;
@@ -228,7 +261,12 @@ namespace T3D
 		setNeedWorldUpdate();
     }
 
-	// Make -ve z axis point at other
+	/*
+	 * This works by making -ve z axis point at other
+	 *
+	 * \param target transform to look at
+	 * \param up upwards direction relative to transform
+	 */
 	void Transform::lookAt(Vector3 target, Vector3 up){
 		Vector3 vectorTo = target - getWorldPosition();
 
@@ -243,6 +281,18 @@ namespace T3D
 		setNeedWorldUpdate();
 	}
 
+	Matrix4x4 Transform::getLocalMatrix()
+	{
+		if (needLocalUpdate) calcLocalMatrix();
+		return localMatrix;
+	}
+
+	Matrix4x4 Transform::getWorldMatrix()
+	{
+		if (needWorldUpdate) update(false);
+		return worldMatrix;
+	}
+
 	Vector3 Transform::transformPoint(Vector3 &p){
 		return getWorldMatrix()*p;
 	}
@@ -252,16 +302,19 @@ namespace T3D
 		return parent;
 	}
 
+	/*
+	 * \param p New parent
+	 */
 	void Transform::setParent(Transform* p)
 	{
 		if (parent != p)
 		{
-			if(NULL != parent)
+			if(parent)
 			{
 				parent->removeChild(this);
 				parent = NULL;
 			}
-			if(NULL != p)
+			if(p)
 			{
 				p->addChild(this);
 			}
@@ -270,68 +323,101 @@ namespace T3D
 		}
 	}
 
-	void Transform::addChild(Transform* c)
-	{
-		children.push_back(c);
-	}
-
-	void Transform::removeChild(Transform* c)
-	{
-		if(NULL != c && !children.empty())
-		{
-			for(unsigned int i = 0; i < children.size(); ++i)
-			{
-				if(children[i] == c)
-				{
-					children.erase(children.begin() + i);
-					break; // break the for loop
-				}
-			}
-		}
-	}
-
 	std::string Transform::getName(void) const
 	{
 		return name;
 	}
 
+	/*
+	 * \param n Name of child.
+	 * \return The child or `NULL`
+	 */
 	Transform* Transform::getChildByName(std::string n)
 	{
-		if(!children.empty())
+		for(auto child: children)
 		{
-			for(unsigned int i = 0; i < children.size(); ++i)
+			if(0 == n.compare(child->name))
 			{
-				if(0 == n.compare(children[i]->name))
-				{
-					return children[i];
-				}
+				return child;
 			}
 		}
+
+		logger::Log(priority::Warning,
+					output_stream::File,
+					category::Game,
+					"Warning: Searched for nonexistent child by name in scenegraph.\n"
+					"\tRoot of scenegraph name: %s\n"
+					"\tChild name             : %s\n"
+					,
+					this->name.c_str(),
+					n.c_str());
+
 		return NULL;
 	}
 
+	/*
+	 * \param n Name of ancestor.
+	 * \return The ancestor or `NULL`
+	 */
 	Transform* Transform::getAncestorByName(std::string n)
 	{
+		logger::Log(priority::Info,
+					output_stream::File,
+					category::Game,
+					"Searching scenegraph from child %s for ancestor node %s...."
+					,
+					this->name.c_str(),
+					n.c_str());
+					
 		std::queue<Transform*> q;
 		Transform* current = this;
 
-		while (current!=NULL && n.compare(current->name) != 0){
-			std::cout << "processing " << current->name << "\n";
-			if(!current->children.empty())
-			{
-				for(unsigned int i = 0; i < current->children.size(); ++i)
-				{
-					q.push(current->children[i]);
-				}
+		while (current && n.compare(current->name) != 0) {
+			logger::Log(priority::Info,
+						output_stream::File,
+						category::Game,
+						"processing %s...." , current->name.c_str());
+
+			for (auto child: current->children) {
+				q.push(child);
 			}
-			if (q.empty()){
+
+			if (q.empty()) {
 				current = NULL;
 			} else {
 				current = q.front();
 				q.pop();
 			}
 		}
+
 		return current;
+	}
+
+	/*
+	 * \param c child to add
+	 */
+	void Transform::addChild(Transform* c)
+	{
+		children.push_back(c);
+	}
+
+
+	/*
+	 * \param c child to remove
+	 * \note Does nothing if `c` is `NULL` or isn't a child of the Transform
+	 */
+	void Transform::removeChild(Transform* c)
+	{
+		if(!c) return;
+
+		for(unsigned int i = 0; i < children.size(); ++i)
+		{
+			if(children[i] == c)
+			{
+				children.erase(children.begin() + i);
+				break; // break the for loop
+			}
+		}
 	}
 }
 

--- a/T3D/T3D/Transform.h
+++ b/T3D/T3D/Transform.h
@@ -8,67 +8,119 @@
 //
 // The base class for the scene graph
 // Adapted from http://scriptionary.com/2009/02/17/simple-scene-graph-in-c/
-
-
-#ifndef TRANSFORM_H
-#define TRANSFORM_H
+#pragma once
 
 #include <vector>
 #include <string>
 #include <iostream>
-#include "Matrix4x4.h"
+
 #include "Component.h"
+#include "Matrix4x4.h"
 #include "Quaternion.h"
 
 namespace T3D
 {
+	//! \brief Transform nodes form a hierarchical scene graph. 
+	/*
+	 * A Transform has a position and rotation relative to an optional parent Transform, and a container of optional children Transforms.
+	 * The root of a scene and its immediate children define world space.
+	 * 
+	 * The implementation is similiar to Ogre3D's lazily updated hieararchical scenegraph that only updates local matrices of descendants when there has been a change to an ancestor.
+	 *
+	 * Many convenient functions are provided for querying, adding and updating Transforms with respect to the hierarchy.
+	 *
+	 */
 	class Transform: public Component
 	{
 	public:
+		//! \brief Create named Transform relative to a parent.
 		Transform(Transform* parent = NULL, std::string name = "noname");
+
+		//! \brief Destroy Transform and its children.
 		~Transform(void);
  
+		//! \brief Update the scenegraph, recursively by default.
 		virtual void update(bool updateChildren = true);
  
+		//! \brief Get parent
 		Transform* getParent(void) const;
+
+		//! \brief Set parent, updating the hierarchy recursively.
 		void setParent(Transform* p);
  
-	private:
-		void addChild(Transform* c);
-		void removeChild(Transform* c);
- 
-	public:
+		//! \brief Get name
 		std::string getName(void) const;
  
+		//! \brief Get child by name. Does not recurse.
 		Transform* getChildByName(std::string n);
+
+		//! \brief Get ancestor by name.
 		Transform* getAncestorByName(std::string n);
 
+		//! \brief Set local position, updating children if needed.
 		void setLocalPosition(const Vector3& pos);
+
+		//! \brief Set world position, updating children if needed.
 		void setWorldPosition(const Vector3& pos);
+
+		//! \brief Set local rotation, updating children if needed.
 		void setLocalRotation(const Vector3& rot);
+
+		//! \brief Set local rotation, updating children if needed.
 		void setLocalRotation(Quaternion& q);
+
+		//! \brief Set local scale, updating children if needed.
 		void setLocalScale(const Vector3& scl);
 
-		void move(const Vector3& delta);void Transform::roll(const float angle);
+		//! \brief Update position by moving (translate) a distance
+		void move(const Vector3& delta);
+
+		//! \brief Update rotation, by rolling by an angle
+		void roll(const float angle);
+
+		//! \brief Update rotation by pitching by an angle
 		void pitch(const float angle);
+
+		//! \brief Update rotation by yawing by an angle
 		void yaw(const float angle);
+
+		//! \brief Update rotation using an angle-axis pair
 		void rotate(const Vector3& axis, const float angle);
+
+		//! \brief Update rotation using a quaternion
 		void rotate(Quaternion& q);
+
+		//! \brief Update rotation using euler angles
 		void rotate(const Vector3& eulers);
 
+		//! \brief Update rotation by 'looking at' a target transform
 		void lookAt(Vector3 target, Vector3 up = Vector3(0,1,0));
 
+		//! \brief Get local matrix, i.e. relative to parent
 		Matrix4x4 getLocalMatrix();
+
+		//! \brief Get world matrix, i.e. relative to root of scene graph
 		Matrix4x4 getWorldMatrix();
-		
+
+		//! \brief Get local position, i.e. relative to parent
 		const Vector3 getLocalPosition();
+
+		//! \brief Get local rotation as euler angles,
 		const Vector3 getEulerAngles();
+
+		//! \brief Get local rotation as quaternion, 
 		const Quaternion getQuaternion();
+
+		//! \brief Get rotation matrix, i.e. without transform component
 		const Matrix3x3 getRotationMatrix(){ return rotationMatrix; }
+
+		//! \brief Get local scale, i.e. relative to parent
 		const Vector3 getLocalScale();
 		
+		//! \brief Get world postion, i.e. relative to root of scene graph
 		const Vector3 getWorldPosition();
 
+		//! \brief Move a point `P` into world space `S` relative to this transforms world space
 		Vector3 transformPoint(Vector3 &p);
 		
         inline friend std::ostream& operator <<
@@ -79,25 +131,49 @@ namespace T3D
 			return o;
         }
 
+		//! \brief Parent of Transform. `NULL` for the root.
+		Transform* parent;
+
+		//! \brief Name of this Transform, for searching/querying/animation bones/debugging. Defaults to `noname`.
+		std::string name;
+
+		//! \brief Children of Transform. size() == 0 for a leaf Transform.
+		std::vector<Transform*> children;
+
 	private:
+
+		//! \brief Add child.
+		void addChild(Transform* c);
+
+		//! \brief Remove child
+		void removeChild(Transform* c);
+
+		//! \brief Update local matrix and reset local dirty bit.
 		void calcLocalMatrix();
+
+		//! \brief Set world update bit to dirty.
 		void setNeedWorldUpdate();
 
+		//! \brief Matrix relative to parent.
 		Matrix4x4 localMatrix;
+
+		//! \brief Matrix relative to root of scene graph.
 		Matrix4x4 worldMatrix;
+
+		//! \brief Local update flag.
 		bool needLocalUpdate;
+
+		//! \brief World update flag.
 		bool needWorldUpdate;
 		
+		//! \brief Translation component of local matrix.
 		Matrix4x4 translationMatrix;
+
+		//! \brief Rotation component of local matrix.
 		Matrix3x3 rotationMatrix;
+
+		//! \brief Scale component of local matrix.
 		Matrix3x3 scaleMatrix;
 
-	public:
-		Transform* parent;
-		std::string name;
-		std::vector<Transform*> children;
 	}; 
 }
-
-#endif
-

--- a/T3D/T3D/Tutorial1.cpp
+++ b/T3D/T3D/Tutorial1.cpp
@@ -9,19 +9,17 @@
 // Base application for tutorial 1.  Used in conjunction with DrawTask, a task for drawing onto a 2D texture.
 
 #include "Tutorial1.h"
+#include "WinGLApplication.h"
+#include "GLRenderer.h"
 #include "Camera.h"
 
-namespace T3D{
-
+namespace T3D 
+{
 	Tutorial1::Tutorial1(void)
 	{
-		drawArea = new Texture(1024,640,false);
+		drawTask = nullptr;
+		drawArea = new Texture(renderer->WindowWidth, renderer->WindowHeight, false);
 		drawArea->clear(Colour(255,255,255,255));
-	}
-
-
-	Tutorial1::~Tutorial1(void)
-	{
 	}
 
 	bool Tutorial1::init(){

--- a/T3D/T3D/Tutorial1.h
+++ b/T3D/T3D/Tutorial1.h
@@ -9,18 +9,20 @@
 // Base application for tutorial 1.  Used in conjunction with DrawTask, a task for drawing onto a 2D texture.
 
 #pragma once
-#include "winglapplication.h"
+
+#include "WinGLApplication.h"
 #include "Texture.h"
 #include "DrawTask.h"
 
-namespace T3D{
-
+namespace T3D
+{
+	//! \brief Tutorial1 Driver
 	class Tutorial1 :
 		public WinGLApplication
 	{
 	public:
 		Tutorial1(void);
-		~Tutorial1(void);
+		~Tutorial1(void) = default;
 
 		bool init();
 

--- a/T3D/T3D/Vector3.h
+++ b/T3D/T3D/Vector3.h
@@ -8,9 +8,7 @@
 //
 // 3d vector class
 // Adapted from Ogre3D
-
-#ifndef VECTOR3_H
-#define VECTOR3_H
+#pragma once
 
 #include <algorithm>
 #include <iostream>
@@ -19,6 +17,7 @@
 
 namespace T3D
 {
+	//! \brief 3-component Vector.
     class Vector3
     {
     public:
@@ -390,5 +389,3 @@ namespace T3D
     };
 
 }
-
-#endif

--- a/T3D/T3D/Vector4.h
+++ b/T3D/T3D/Vector4.h
@@ -8,9 +8,7 @@
 //
 // 3d homogeneous vector class
 // Adapted from Ogre3D
-
-#ifndef VECTOR4_H
-#define VECTOR4_H
+#pragma once
 
 #include <algorithm>
 #include <iostream>
@@ -21,6 +19,7 @@
 
 namespace T3D
 {
+	//! \brief 4-component Vector, with homogeneous w.
 	class Vector4
     {
     public:
@@ -276,5 +275,3 @@ namespace T3D
         }
     };
 }
-
-#endif

--- a/T3D/T3D/WinGLApplication.h
+++ b/T3D/T3D/WinGLApplication.h
@@ -7,18 +7,16 @@
 // winglapplication.h
 //
 // t3d application for windows and OpenGL
-
-#ifndef WINGLAPPLICATION_H
-#define WINGLAPPLICATION_H
+#pragma once
 
 #include <sdl\SDL.h>
 
-#include "t3dapplication.h"
+#include "T3DApplication.h"
 #include "FontCache.h"
 
 namespace T3D 
 {
-
+	//! \brief Application driver using Win32, OpenGL 1.x and SDL.
 	class WinGLApplication :
 		public T3DApplication
 	{
@@ -41,6 +39,3 @@ namespace T3D
 	};
 
 }
-
-#endif
-


### PR DESCRIPTION
## This is a large commit, but it is primarily documenting and tidying declarations in nearly every T3D source and header, and some neatening / shrinking of leaf code

T3D's design, semantics and control flow are *identical* after these changes. In fact, even after adding a *lot* of documentation there's only a +800 line delta.

### Summary of most changes

- Consistent use of `#pragma once` instead of `#ifdef` guards
- Consistently use doxygen-style documentation; `\brief` with declarations, everything else with definitions, except for inlined or tiny member functions/variables
- Consistently use delegated constructors (this actually _removes_ a few empty `.cpp` files as a result!)
- Fix the rather tangled mess of source files having transient dependencies on headers included in arbitrarily different locations - for example, a `Task` subclass depending on `WinGLApplication` pulling in `iostream` for its declaration of `std::string`! 
- Use `std::` explicitly for STL containers

### 'Bigger' changes that make code clearer by branching, condensing, and removing code (with a little bit of adding):
- Condense a _lot_ of copy-paste code, for example in `GLRenderer.cpp`, `Mesh.cpp`, `Plane.cpp`
- Use range-based loops for read-only walking of collections - shorter and much clearer
- Make control flow of animation-related classes clearer, especially `Bone.cpp` and `Animation.cpp`
- Split `Camera` and `Material` constructors to reduce copy-pasting and help prevent misuse
- Remove a lot of redundant header file includes -- speeds up compilation noticably


### Pure additions
- Instrument lower-level code with `logger::Log` calls for info, trace and warnings. These are disabled by default in `WinGLApplication`. This gives _much_ better warning and error messages from the perspective of a recent student -- for example, errors in shader compilation, wrong file paths and so on.
