### PR TITLE
Add version to test GLSL code.

### DIFF
--- a/T3D/T3D/Resources/vert.shader
+++ b/T3D/T3D/Resources/vert.shader
@@ -1,3 +1,4 @@
+#version 130
 out vec4 color;
 
 void main()

--- a/T3D/T3D/Resources/vspecular.shader
+++ b/T3D/T3D/Resources/vspecular.shader
@@ -1,3 +1,4 @@
+#version 130
 out vec4 color;
 
 void main()


### PR DESCRIPTION
This allows `ShaderTest.cpp` to run as intended by explicitly annotating compatibility GLSL. This is just an alternative to using `gl_Color` and other legacy bits on modern drivers.